### PR TITLE
fix: ensure semaphore is closed after use

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,6 +92,7 @@ var rootCmd = &cobra.Command{
 		}
 		wg.Wait()
 		defer close(idListChan)
+		defer close(sem)
 		logger.Info("video list", "count", len(idList))
 		// natural.Sort(idList
 		NiconicoSort(idList, tab, url)


### PR DESCRIPTION
### Pull Request Description

**Title:** fix: ensure semaphore is closed after use

**Description:**
This pull request introduces a critical fix to ensure that the semaphore channel is properly closed after its usage. A `defer` statement has been added in the root to facilitate this cleanup. 

**Key Changes:**
- Implemented a `defer` statement to close the semaphore channel.
- This change addresses potential resource leaks that could occur if the semaphore is not closed properly.
- Enhances the overall stability and reliability of the application by ensuring that resources are managed correctly.

By merging this pull request, we aim to improve the application's resource management and prevent any unforeseen issues related to semaphore usage.