### PR TITLE
Add backoff sleep to retriesRequest

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -210,6 +210,8 @@ func retriesRequest(url string) (*http.Response, error) {
 		err     error
 		retries = 100
 	)
+	const baseDelay = 50 * time.Millisecond
+	maxRetries := retries
 
 	for retries > 0 {
 		res, err = client.Do(req)
@@ -219,6 +221,8 @@ func retriesRequest(url string) (*http.Response, error) {
 			}
 		}
 		retries--
+		wait := baseDelay * time.Duration(maxRetries-retries)
+		time.Sleep(wait)
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Summary
- retriesRequestでリトライ時に待機時間を増やすよう変更

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684437d8b4bc832387b2e6bfce5e76d9