### PR TITLE
Add page flag without env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ Flags:
   -h, --help                  help for go-nico-list
   -t, --tab                   id tab Separated flag
   -u, --url                   output id add url
+  -p, --pages number          maximum number of pages to fetch
   -v, --version               version for go-nico-list
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ var (
 	datebefore string
 	tab        bool
 	url        bool
+	pageLimit  int
 	logger     *slog.Logger
 )
 
@@ -96,8 +97,9 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 }
 
 const (
-	tabStr = "\t\t\t\t\t\t\t\t\t"
-	urlStr = "https://www.nicovideo.jp/watch/"
+	tabStr           = "\t\t\t\t\t\t\t\t\t"
+	urlStr           = "https://www.nicovideo.jp/watch/"
+	defaultPageLimit = 100
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -123,6 +125,9 @@ func init() {
 	rootCmd.Flags().StringVarP(&datebefore, "datebefore", "b", "99991231", "date `YYYYMMDD` before")
 	rootCmd.Flags().BoolVarP(&tab, "tab", "t", false, "id tab Separated flag")
 	rootCmd.Flags().BoolVarP(&url, "url", "u", false, "output id add url")
+
+	pageLimitDefault := defaultPageLimit
+	rootCmd.Flags().IntVarP(&pageLimit, "pages", "p", pageLimitDefault, "maximum number of pages to fetch")
 	info, ok := debug.ReadBuildInfo()
 	if ok {
 		rootCmd.Version = info.Main.Version
@@ -155,7 +160,7 @@ func getVideoList(userID string, commentCount int, afterDate time.Time, beforeDa
 		beforeStr += urlStr
 	}
 
-	for i := 0; i < 100; i++ {
+	for i := 0; i < pageLimit; i++ {
 		url := fmt.Sprintf("https://nvapi.nicovideo.jp/v3/users/%s/videos?pageSize=100&page=%d", userID, i+1)
 		res, err := retriesRequest(url)
 		if err != nil {


### PR DESCRIPTION
## Summary
- ページ取得回数を管理する定数 `defaultPageLimit` を追加
- `--pages` フラグのみで取得件数を変更できるよう修正
- README から環境変数の記述を削除

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68444efcddb88323b3941a0babd961d0