### PR TITLE
Use subtests for TestNiconicoSort

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -39,11 +39,14 @@ func TestNiconicoSort(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		slice := append([]string(nil), tt.input...)
-		NiconicoSort(slice, tt.tab, tt.url)
-		if !reflect.DeepEqual(slice, tt.expected) {
-			t.Errorf("%s: expected %v, got %v", tt.name, tt.expected, slice)
-		}
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			slice := append([]string(nil), tt.input...)
+			NiconicoSort(slice, tt.tab, tt.url)
+			if !reflect.DeepEqual(slice, tt.expected) {
+				t.Errorf("%s: expected %v, got %v", tt.name, tt.expected, slice)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- refactor TestNiconicoSort to use `t.Run`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844c8a2b22883239fe7101bf08fd6c7