### PR TITLE
Context-aware retries with timeout

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestNiconicoSort(t *testing.T) {
@@ -62,7 +64,9 @@ func TestRetriesRequest(t *testing.T) {
 	}))
 	defer server.Close()
 
-	res, err := retriesRequest(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	res, err := retriesRequest(ctx, server.URL)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- HTTPリトライ処理にcontextを導入し、`http.NewRequestWithContext`を利用
- リトライ回数や待機時間、タイムアウトを定数化
- `getVideoList`から`context.WithTimeout`を渡すよう修正
- テストを更新してcontext利用を確認

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844c8ab9bd08323aa435227c4164ab1