### PR TITLE
NiconicoSort に長さチェックを追加

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -145,7 +145,20 @@ func NiconicoSort(slice []string, tab bool, url bool) {
 	}
 	str := "%08s"
 
-	sort.Slice(slice, func(i, j int) bool { return fmt.Sprintf(str, slice[i][num:]) < fmt.Sprintf(str, slice[j][num:]) })
+	sort.Slice(slice, func(i, j int) bool {
+		var s1, s2 string
+		if len(slice[i]) >= num {
+			s1 = slice[i][num:]
+		} else {
+			s1 = slice[i]
+		}
+		if len(slice[j]) >= num {
+			s2 = slice[j][num:]
+		} else {
+			s2 = slice[j]
+		}
+		return fmt.Sprintf(str, s1) < fmt.Sprintf(str, s2)
+	})
 }
 
 // GetVideoList retrieves video IDs for a user

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -38,6 +38,20 @@ func TestNiconicoSort(t *testing.T) {
 			url:      true,
 			expected: []string{tabStr + urlStr + "sm1", tabStr + urlStr + "sm2", tabStr + urlStr + "sm10"},
 		},
+		{
+			name:     "shortString",
+			input:    []string{"sm12", "s", "sm3"},
+			tab:      false,
+			url:      false,
+			expected: []string{"sm3", "s", "sm12"},
+		},
+		{
+			name:     "shortStringTabURL",
+			input:    []string{tabStr + urlStr + "sm2", tabStr + urlStr + "s", tabStr + urlStr + "sm10"},
+			tab:      true,
+			url:      true,
+			expected: []string{tabStr + urlStr + "s", tabStr + urlStr + "sm2", tabStr + urlStr + "sm10"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `NiconicoSort` で文字列長を確認し、安全に比較できるよう修正
- `root_test.go` に短い文字列用のテストケースを追加

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844d0a69b808323ab418a45b54e00a8