### PR TITLE
Add tests for getVideoList

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,7 +83,7 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 			defer wg.Done()
 			defer func() { <-sem }()
 			defer bar.Add(1)
-			newList := getVideoList(userID, comment, afterDate, beforeDate, tab, url)
+			newList := getVideoList(userID, comment, afterDate, beforeDate, tab, url, defaultBaseURL)
 			mu.Lock()
 			idList = append(idList, newList...)
 			mu.Unlock()
@@ -101,6 +101,7 @@ const (
 	tabStr           = "\t\t\t\t\t\t\t\t\t"
 	urlStr           = "https://www.nicovideo.jp/watch/"
 	defaultPageLimit = 100
+	defaultBaseURL   = "https://nvapi.nicovideo.jp/v3"
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -162,7 +163,7 @@ func NiconicoSort(slice []string, tab bool, url bool) {
 }
 
 // GetVideoList retrieves video IDs for a user
-func getVideoList(userID string, commentCount int, afterDate time.Time, beforeDate time.Time, tab bool, url bool) []string {
+func getVideoList(userID string, commentCount int, afterDate time.Time, beforeDate time.Time, tab bool, url bool, baseURL string) []string {
 
 	var resStr []string
 
@@ -175,7 +176,7 @@ func getVideoList(userID string, commentCount int, afterDate time.Time, beforeDa
 	}
 
 	for i := 0; i < pageLimit; i++ {
-		requestURL := fmt.Sprintf("https://nvapi.nicovideo.jp/v3/users/%s/videos?pageSize=100&page=%d", userID, i+1)
+		requestURL := fmt.Sprintf("%s/users/%s/videos?pageSize=100&page=%d", baseURL, userID, i+1)
 		res, err := retriesRequest(context.Background(), requestURL)
 		if err != nil {
 			break

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestNiconicoSort(t *testing.T) {
@@ -99,5 +100,37 @@ func TestRetriesRequestContextCanceled(t *testing.T) {
 	}
 	if res != nil {
 		t.Errorf("expected nil response, got %v", res)
+	}
+}
+
+func TestGetVideoList(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		var resp string
+		switch page {
+		case "1":
+			resp = `{"data":{"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}},{"essential":{"id":"sm2","registeredAt":"2024-01-15T00:00:00Z","count":{"comment":3}}}]}}`
+		case "2":
+			resp = `{"data":{"items":[{"essential":{"id":"sm3","registeredAt":"2024-02-10T00:00:00Z","count":{"comment":20}}},{"essential":{"id":"sm4","registeredAt":"2024-05-02T00:00:00Z","count":{"comment":30}}}]}}`
+		default:
+			resp = `{"data":{"items":[]}}`
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	oldLimit := pageLimit
+	pageLimit = 3
+	defer func() { pageLimit = oldLimit }()
+
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	got := getVideoList("12345", 5, after, before, false, false, server.URL)
+	expected := []string{"sm1", "sm3"}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("expected %v, got %v", expected, got)
 	}
 }


### PR DESCRIPTION
## Summary
- allow `getVideoList` to accept base URL
- add `defaultBaseURL` constant
- call `getVideoList` using `defaultBaseURL`
- add mock server based test for `getVideoList`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844d2079a748323ba7172b081e95379