### PR TITLE
Fix user ID validation in main loop

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,8 +72,13 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 
 	for i := range args {
 		sem <- struct{}{}
-		wg.Add(1)
 		match := r.FindStringSubmatch(args[i])
+		if len(match) == 0 {
+			logger.Warn("invalid user ID", "input", args[i])
+			<-sem
+			continue
+		}
+		wg.Add(1)
 		result := make(map[string]string)
 		for j, name := range r.SubexpNames() {
 			if j != 0 && name != "" {


### PR DESCRIPTION
## Summary
- `FindStringSubmatch` の結果が空の場合に警告を出してループを継続するよう修正
- 無効な入力時にセマフォを解放するよう変更

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844d764e9f88323b1f697cfb01df54c