### PR TITLE
Add concurrency flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ Flags:
   -t, --tab                   id tab Separated flag
   -u, --url                   output id add url
   -p, --pages number          maximum number of pages to fetch
+  -n, --concurrency number    number of concurrent requests (default 30)
   -v, --version               version for go-nico-list
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ var (
 	datebefore        string
 	tab               bool
 	url               bool
+	concurrency       int = 30
 	pageLimit         int
 	httpClientTimeout time.Duration = defaultHTTPTimeout
 	logger            *slog.Logger
@@ -67,7 +68,7 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 	r := regexp.MustCompile(`(((http(s)?://)?www\.)?nicovideo.jp/)?user/(?P<userID>\d{1,9})(/video)?`)
 	bar := progressbar.Default(int64(len(args)))
 
-	sem := make(chan struct{}, 30)
+	sem := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
 
 	for i := range args {
@@ -135,6 +136,8 @@ func init() {
 	rootCmd.Flags().StringVarP(&datebefore, "datebefore", "b", "99991231", "date `YYYYMMDD` before")
 	rootCmd.Flags().BoolVarP(&tab, "tab", "t", false, "id tab Separated flag")
 	rootCmd.Flags().BoolVarP(&url, "url", "u", false, "output id add url")
+
+	rootCmd.Flags().IntVarP(&concurrency, "concurrency", "n", 30, "number of concurrent requests")
 
 	pageLimitDefault := defaultPageLimit
 	rootCmd.Flags().IntVarP(&pageLimit, "pages", "p", pageLimitDefault, "maximum number of pages to fetch")


### PR DESCRIPTION
## Summary
- `--concurrency` フラグに `-n` ショートハンドを追加
- README のフラグ一覧を更新

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844d8cca5008323b72eb1cae11105ea