### PR TITLE
fix retries body close

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -251,8 +251,11 @@ func retriesRequest(ctx context.Context, url string) (*http.Response, error) {
 			if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusNotFound {
 				break
 			}
+			res.Body.Close()
 		} else if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
+		} else if res != nil {
+			res.Body.Close()
 		}
 		retries--
 		wait := time.Duration(math.Min(math.Pow(2, float64(maxRetries-retries))*float64(baseDelay), float64(30*time.Second)))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -93,6 +93,7 @@ func TestRetriesRequest(t *testing.T) {
 	if count != 3 {
 		t.Errorf("expected 3 attempts, got %d", count)
 	}
+	res.Body.Close()
 }
 
 func TestRetriesRequestBackoff(t *testing.T) {
@@ -127,6 +128,7 @@ func TestRetriesRequestBackoff(t *testing.T) {
 	if diff2 < 200*time.Millisecond {
 		t.Errorf("second backoff too short: %v", diff2)
 	}
+	res.Body.Close()
 }
 
 func TestRetriesRequestContextCanceled(t *testing.T) {


### PR DESCRIPTION
## Summary
- ensure HTTP body is closed when status code is unexpected
- close response bodies in tests

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844e04b691c83239c92d407fb7bd19e