### PR TITLE
Add timeout and retries flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,7 @@ Flags:
   -u, --url                   output id add url
   -p, --pages number          maximum number of pages to fetch
   -n, --concurrency number    number of concurrent requests (default 30)
+      --timeout duration      HTTP client timeout (default "10s")
+      --retries number        number of retries for requests (default 100)
   -v, --version               version for go-nico-list
 ```


### PR DESCRIPTION
## Summary
- HTTPクライアントのタイムアウトとリトライ回数を指定できる`--timeout`と`--retries`フラグを追加
- READMEのフラグ一覧を更新

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844ea0d46d48323aa1a5d6ad3fca22a