### PR TITLE
Validate concurrency option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,10 @@ var rootCmd = &cobra.Command{
 }
 
 func runRootCmd(cmd *cobra.Command, args []string) error {
+	if concurrency < 1 {
+		return errors.New("concurrency must be at least 1")
+	}
+
 	const dateFormat = "20060102"
 
 	t, err := time.Parse(dateFormat, dateafter)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -330,3 +330,15 @@ func TestGetVideoListHandleServerError(t *testing.T) {
 		t.Errorf("expected 2 attempts, got %d", count)
 	}
 }
+
+func TestConcurrencyValidation(t *testing.T) {
+	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	concurrency = 0
+	defer func() { concurrency = 30 }()
+
+	rootCmd.SetArgs([]string{"12345"})
+	err := rootCmd.Execute()
+	if err == nil || err.Error() != "concurrency must be at least 1" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `concurrency` が 1 未満のときは `runRootCmd` でエラーを返すよう修正
- 単体テストではエラーメッセージを確認する形に変更

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844f4c8b9988323964a81a6ac61e3b6