### PR TITLE
Update README for flag caution

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ Flags:
   -u, --url                   output id add url
   -p, --pages number          maximum number of pages to fetch
   -n, --concurrency number    number of concurrent requests (default 30)
+                           (recommended 30, minimum 1)
       --timeout duration      HTTP client timeout (default "10s")
   --retries number        number of retries for requests (default 100)
-                           (minimum value is 1)
+                           (recommended 100, minimum 1)
   -v, --version               version for go-nico-list
 ```
+
+Setting `concurrency` or `retries` to a value less than 1 will cause a runtime error.
+The recommended values are `30` for `concurrency` and `100` for `retries`, so avoid using values that are too small.


### PR DESCRIPTION
## Summary
- README の注意書きを英語化し、 `concurrency` と `retries` に誤った値を設定しないよう警告を記載しました

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68450b84d1148323ade869d5156fdc23