### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-﻿### visualstudiocode
+### visualstudiocode
 
 .vscode/*
 !.vscode/settings.json
@@ -63,4 +63,3 @@ $RECYCLE.BIN/
 
 dist/
 
-.jj/


### PR DESCRIPTION
## Summary
.gitignore の先頭に存在した UTF-8 BOM を削除し、末尾の `.jj/` エントリも削除しました。

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68452da4d5388323aa33a8fa093bb7c5