### PR TITLE
Fix getVideoList error handling

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -223,7 +223,10 @@ func getVideoList(ctx context.Context, userID string, commentCount int, afterDat
 		requestURL := fmt.Sprintf("%s/users/%s/videos?pageSize=100&page=%d", baseURL, userID, i+1)
 		res, err := retriesRequest(ctx, requestURL)
 		if err != nil {
-			break
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, nil
+			}
+			return nil, err
 		}
 		if res != nil {
 			if res.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
## Summary
- `getVideoList` で `retriesRequest` のエラー処理を修正し、キャンセルやタイムアウト時は `nil` を返すように変更

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68452f420c388323a580b6ca6b106673