### PR TITLE
Use per-call http client

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,6 @@ var (
 	retries           int = defaultRetries
 	pageLimit         int
 	httpClientTimeout time.Duration = defaultHTTPTimeout
-	httpClient                      = &http.Client{Timeout: defaultHTTPTimeout}
 	logger            *slog.Logger
 	progressBarNew    func(int64, ...string) *progressbar.ProgressBar = progressbar.Default
 )
@@ -268,7 +267,7 @@ func retriesRequest(ctx context.Context, url string) (*http.Response, error) {
 	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
 	req.Header.Set("X-Frontend-Id", "6")
 	req.Header.Set("Accept", "*/*")
-	httpClient.Timeout = httpClientTimeout
+	client := &http.Client{Timeout: httpClientTimeout}
 
 	var (
 		res *http.Response
@@ -279,7 +278,7 @@ func retriesRequest(ctx context.Context, url string) (*http.Response, error) {
 	attempts := retries
 
 	for attempts > 0 {
-		res, err = httpClient.Do(req)
+		res, err = client.Do(req)
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				if res != nil {


### PR DESCRIPTION
## Summary
- `retriesRequest` で共有 `http.Client` の代わりに毎回新しいクライアントを生成

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684531f028388323b0ce933e578abe21