### PR TITLE
Handle request creation error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -264,14 +264,16 @@ func getVideoList(ctx context.Context, userID string, commentCount int, afterDat
 }
 
 func retriesRequest(ctx context.Context, url string) (*http.Response, error) {
-	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Set("X-Frontend-Id", "6")
 	req.Header.Set("Accept", "*/*")
 	client := &http.Client{Timeout: httpClientTimeout}
 
 	var (
 		res *http.Response
-		err error
 	)
 	const baseDelay = 50 * time.Millisecond
 	maxRetries := retries


### PR DESCRIPTION
## Summary
`http.NewRequestWithContext` のエラーを変数で受け取り、失敗時には即座に返すよう修正しました。

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68453398cf9483238f44fc7d3de96537