### PR TITLE
Move data struct to internal pkg

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/schollz/progressbar/v3"
+	"github.com/sh4869221b/go-nico-list/internal/niconico"
 
 	"github.com/spf13/cobra"
 )
@@ -238,7 +239,7 @@ func getVideoList(ctx context.Context, userID string, commentCount int, afterDat
 				return nil, err
 			}
 
-			var nicoData nicoData
+			var nicoData niconico.NicoData
 			if err := json.Unmarshal(body, &nicoData); err != nil {
 				logger.Error("failed to unmarshal response body", "error", err)
 				return nil, err

--- a/internal/niconico/nico_data.go
+++ b/internal/niconico/nico_data.go
@@ -1,10 +1,10 @@
-package cmd
+package niconico
 
 import (
 	"time"
 )
 
-type nicoData struct {
+type NicoData struct {
 	Meta struct {
 		Status int `json:"status"`
 	} `json:"meta"`


### PR DESCRIPTION
## Summary
- move `nico_data.go` into new `internal/niconico` package
- update package name and expose `NicoData`
- import new package in root command and use new type

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68456569bda48323b2f189cc858d2aff