### PR TITLE
docs: switch to AI-Assisted trailer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ If the idea is not finalized yet, put it in `IMPROVEMENTS.md` instead of `DESIGN
 - Allowed types: `feat`, `fix`, `docs`, `ci`, `chore`, `refactor`, `test`, `build`.
 - Keep the summary on the first line.
 - For complex changes (multiple files or behavior changes), add a blank line, then details from line 3 onward.
-- When Codex is used, add the trailer line: `Co-authored-by: Codex <codex@openai.com>`.
+- When Codex is used, add the trailer line: `AI-Assisted: Codex`.
 
 Example:
 


### PR DESCRIPTION
## Summary\n- switch Codex commit trailer to AI-Assisted format\n\n## What / Why\n- standardize on AI-Assisted: Codex instead of Co-authored-by\n\n## Testing\n- not run (docs change)\n\n## Breaking change\n- [ ] Yes\n- [x] No\n