### PR TITLE
feat: auto-disable progress on non-tty

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -70,7 +70,9 @@ main.go
   - Run summary is emitted to stderr; its `output_count` uses the **deduped** count.
   - `--json` emits a minimal schema (initial fields: `inputs`, `invalid`, `users`, `errors`, `output_count`, `items`).
 - Progress:
-  - Progress output is auto-disabled on non-TTY stderr (with `--no-progress` / `--progress` overrides).
+  - Progress output is auto-disabled on non-TTY stderr.
+  - `--progress` forces progress on even when stderr is not a TTY.
+  - `--no-progress` always disables progress output and takes precedence when both flags are set.
 
 ## Flow
 1. `cmd/root.go` extracts userIDs using the regex.

--- a/README.ja.md
+++ b/README.ja.md
@@ -57,12 +57,15 @@ cat users.txt | go-nico-list --stdin
 | `--input-file` | read inputs from file (newline-separated) | `""` |
 | `--stdin` | read inputs from stdin (newline-separated) | `false` |
 | `--logfile` | log output file path | `""` |
+| `--progress` | force enable progress output | `false` |
+| `--no-progress` | disable progress output | `false` |
 
 Notes:
 - 入力は引数、`--input-file`、`--stdin` で指定できます（改行区切り）。
 - 各入力は `nicovideo.jp/user/<id>` を含む必要があります（スキームは任意）。数字のみや `user/<id>` だけの入力は無効としてスキップされます。
 - 結果は stdout、進捗とログは stderr に出力されます。`--logfile` でログ出力先を変更できます。
 - `concurrency` または `retries` を 1 未満にすると実行時エラーになります。
+- stderr が TTY でない場合は進捗表示を自動で無効化します。`--progress` で強制表示、`--no-progress` で無効化します（優先）。
 
 ## Design
 CLI 層とドメインロジックを分離し、テストと保守性を高めています。

--- a/README.md
+++ b/README.md
@@ -59,12 +59,15 @@ cat users.txt | go-nico-list --stdin
 | `--input-file` | read inputs from file (newline-separated) | `""` |
 | `--stdin` | read inputs from stdin (newline-separated) | `false` |
 | `--logfile` | log output file path | `""` |
+| `--progress` | force enable progress output | `false` |
+| `--no-progress` | disable progress output | `false` |
 
 Notes:
 - Inputs can be provided via arguments, `--input-file`, and `--stdin` (newline-separated).
 - Each input must contain `nicovideo.jp/user/<id>` (scheme optional). Plain digits or `user/<id>` without the domain are treated as invalid inputs and skipped.
 - Results are written to stdout; progress and logs are written to stderr. Use `--logfile` to redirect logs to a file.
 - Setting `concurrency` or `retries` to a value less than 1 will cause a runtime error.
+- Progress is auto-disabled when stderr is not a TTY. Use `--progress` to force-enable or `--no-progress` to disable (takes precedence).
 
 ## Design
 This project separates the CLI layer from the domain logic so each part is easier to test and maintain.


### PR DESCRIPTION
Add --progress/--no-progress overrides and TTY detection.

Update docs and tests for the new behavior.

AI-Assisted: Codex

Closes #117
