### PR TITLE
feat: add best-effort mode

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -60,6 +60,7 @@ cat users.txt | go-nico-list --stdin
 | `--progress` | force enable progress output | `false` |
 | `--no-progress` | disable progress output | `false` |
 | `--strict` | return non-zero if any input is invalid | `false` |
+| `--best-effort` | always exit 0 while logging fetch errors | `false` |
 
 Notes:
 - 入力は引数、`--input-file`、`--stdin` で指定できます（改行区切り）。
@@ -69,6 +70,7 @@ Notes:
 - stderr が TTY でない場合は進捗表示を自動で無効化します。`--progress` で強制表示、`--no-progress` で無効化します（優先）。
 - 処理後に実行サマリを stderr に出力します（非0終了時も含む）。
 - `--strict` を指定すると、無効な入力がある場合に非0で終了します（有効な結果は出力されます）。
+- `--best-effort` を指定すると取得エラーがあっても終了コードは 0 になります（エラーはログに残ります）。
 
 ## Design
 CLI 層とドメインロジックを分離し、テストと保守性を高めています。

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ cat users.txt | go-nico-list --stdin
 | `--progress` | force enable progress output | `false` |
 | `--no-progress` | disable progress output | `false` |
 | `--strict` | return non-zero if any input is invalid | `false` |
+| `--best-effort` | always exit 0 while logging fetch errors | `false` |
 
 Notes:
 - Inputs can be provided via arguments, `--input-file`, and `--stdin` (newline-separated).
@@ -71,6 +72,7 @@ Notes:
 - Progress is auto-disabled when stderr is not a TTY. Use `--progress` to force-enable or `--no-progress` to disable (takes precedence).
 - A run summary is printed to stderr after processing (even when the exit code is non-zero).
 - `--strict` makes invalid inputs return a non-zero exit code while still outputting valid results.
+- `--best-effort` forces exit code 0 even when fetch errors occur (errors are still logged).
 
 ## Design
 This project separates the CLI layer from the domain logic so each part is easier to test and maintain.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ var (
 	forceProgress     bool
 	noProgress        bool
 	strictInput       bool
+	bestEffort        bool
 	Version           = "unset"
 	logger            *slog.Logger
 	progressBarNew    func(int64, io.Writer, bool) *progressbar.ProgressBar = func(max int64, writer io.Writer, visible bool) *progressbar.ProgressBar {
@@ -238,6 +239,9 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 	if strictInput && atomic.LoadInt64(&invalidInputs) > 0 {
 		return errors.New("invalid input detected")
 	}
+	if bestEffort {
+		return nil
+	}
 	return fetchErrRet
 }
 
@@ -287,6 +291,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&forceProgress, "progress", false, "force enable progress output")
 	rootCmd.Flags().BoolVar(&noProgress, "no-progress", false, "disable progress output")
 	rootCmd.Flags().BoolVar(&strictInput, "strict", false, "return non-zero if any input is invalid")
+	rootCmd.Flags().BoolVar(&bestEffort, "best-effort", false, "always exit 0 while logging fetch errors")
 
 }
 


### PR DESCRIPTION
Allow exit code 0 even when fetch errors occur.

Ensure strict still returns non-zero for invalid inputs.

AI-Assisted: Codex

Closes #112
