### PR TITLE
feat: add dedupe option

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -61,6 +61,7 @@ cat users.txt | go-nico-list --stdin
 | `--no-progress` | disable progress output | `false` |
 | `--strict` | return non-zero if any input is invalid | `false` |
 | `--best-effort` | always exit 0 while logging fetch errors | `false` |
+| `--dedupe` | remove duplicate output IDs before sorting | `false` |
 
 Notes:
 - 入力は引数、`--input-file`、`--stdin` で指定できます（改行区切り）。
@@ -71,6 +72,7 @@ Notes:
 - 処理後に実行サマリを stderr に出力します（非0終了時も含む）。
 - `--strict` を指定すると、無効な入力がある場合に非0で終了します（有効な結果は出力されます）。
 - `--best-effort` を指定すると取得エラーがあっても終了コードは 0 になります（エラーはログに残ります）。
+- `--dedupe` を指定すると動画IDの重複を除外してからソート/出力します。
 
 ## Design
 CLI 層とドメインロジックを分離し、テストと保守性を高めています。

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ cat users.txt | go-nico-list --stdin
 | `--no-progress` | disable progress output | `false` |
 | `--strict` | return non-zero if any input is invalid | `false` |
 | `--best-effort` | always exit 0 while logging fetch errors | `false` |
+| `--dedupe` | remove duplicate output IDs before sorting | `false` |
 
 Notes:
 - Inputs can be provided via arguments, `--input-file`, and `--stdin` (newline-separated).
@@ -73,6 +74,7 @@ Notes:
 - A run summary is printed to stderr after processing (even when the exit code is non-zero).
 - `--strict` makes invalid inputs return a non-zero exit code while still outputting valid results.
 - `--best-effort` forces exit code 0 even when fetch errors occur (errors are still logged).
+- `--dedupe` removes duplicate video IDs before sorting/output.
 
 ## Design
 This project separates the CLI layer from the domain logic so each part is easier to test and maintain.


### PR DESCRIPTION
Remove duplicate output IDs before sorting when --dedupe is set.

Update docs and tests for deduped output.

AI-Assisted: Codex

Closes #113
