### PR TITLE
docs: require PR template usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ Baseline rules for changes in this repository.
 - Use the `branch-helper` skill for tasks that modify the repository unless the user requests otherwise.
 - After addressing review feedback, re-request review and ask Codex for a re-review in chat.
 - PRs must include an auto-close keyword for related issues (e.g. `Closes #123`).
-- When creating PRs with `gh`, use `--fill` or `--body-file` (avoid `-b` with literal `\n`).
+- PR bodies must be based on `.github/PULL_REQUEST_TEMPLATE.md` and keep all sections.
+- When creating PRs with `gh`, always use `--body-file` from the template (avoid `--fill` alone).
 - When editing PR bodies with `gh`, use `-F <file>` and rewrite the full body (no `--add-body` flag exists).
 - For implementation work, always follow this flow: Implement → Test → Review.
   - If the review has findings, ask numbered questions for any confirmations needed.


### PR DESCRIPTION
## Summary

Require PR bodies to be based on the repository template.

## What / Why

- Enforce using `.github/PULL_REQUEST_TEMPLATE.md` so all PRs share the same structure.

## Related issues

N/A

## Testing

Not run (docs-only change).

```bash
# not run
```

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [ ] `go vet ./...`
- [ ] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
