### PR TITLE
docs: require PR fix log

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,10 @@
 # go test ./...
 ```
 
+## Fix log
+
+<!-- Append a short log after each correction pass (e.g. "2026-01-10: fix X, update tests"). -->
+
 ## Breaking change
 
 - [ ] Yes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ Baseline rules for changes in this repository.
 - PRs must include an auto-close keyword for related issues (e.g. `Closes #123`).
 - PR bodies must be based on `.github/PULL_REQUEST_TEMPLATE.md` and keep all sections.
 - When creating PRs with `gh`, always use `--body-file` from the template (avoid `--fill` alone).
+- Create the PR right after the initial implementation commit so fix logs can be tracked in the PR body.
+- Maintain a running fix log in the PR body after each correction pass.
 - When editing PR bodies with `gh`, use `-F <file>` and rewrite the full body (no `--add-body` flag exists).
 - For implementation work, always follow this flow: Implement → Test → Review.
   - If the review has findings, ask numbered questions for any confirmations needed.


### PR DESCRIPTION
## Summary

Add a Fix log section to the PR template and require early PR creation.

## What / Why

- Ensure PRs are created right after the initial implementation commit.
- Keep a running Fix log in the PR body so correction history is visible.

## Related issues

N/A

## Testing

Not run (docs-only change).

```bash
# not run
```

## Fix log

- 2026-01-10: initial documentation update

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [ ] `go vet ./...`
- [ ] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
