### PR TITLE
docs: clarify milestone release workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Baseline rules for changes in this repository.
 - When mocking the niconico API, ensure pagination terminates (e.g. return empty items or 404 for page > 1).
 - Avoid interactive editors in automated merges (use `git merge -m` or set `GIT_EDITOR` to a non-interactive command).
 - Before merging, wait for all CI checks to complete (use `gh pr checks --watch`) unless explicitly told to skip.
+- When a versioned milestone is completed, release using the same version number; after the release workflow succeeds, close the milestone.
 
 ## Design
 Refer to `DESIGN.md` for the design overview and responsibility boundaries.


### PR DESCRIPTION
## Summary

Clarify the release/milestone closure ordering in the workflow rules.

## What / Why

- Document that versioned milestones should trigger a same-version release, then be closed after the release succeeds.

## Related issues

N/A

## Testing

Not run (docs-only change).

```bash
# not run
```

## Fix log

- 2026-01-10: initial documentation update

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [ ] `go vet ./...`
- [ ] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
