### PR TITLE
docs: update release workflow rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
           go-version-file: go.mod
       - name: Download deps
         run: go mod download
+      - name: Verify generated files
+        run: |
+          go mod tidy
+          go generate ./...
+          git diff --exit-code
       - name: Check gofmt
         run: |
           gofmt -w .
@@ -39,7 +44,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: 'latest'
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,10 +66,12 @@ If the idea is not finalized yet, put it in `IMPROVEMENTS.md` instead of `DESIGN
 ## Release process
 
 1. Ensure master is green and up to date.
-2. Create and push a version tag: `vX.Y.Z`.
-3. GitHub Actions runs the release workflow, including gofmt/go vet/go test/go test -race.
-4. The workflow regenerates `THIRD_PARTY_NOTICES.md` and fails if it is out of date.
-5. GoReleaser publishes the GitHub Release and uploads artifacts.
+2. If a versioned milestone is complete, release using the same version number.
+3. Create and push a version tag: `vX.Y.Z`.
+4. GitHub Actions runs the release workflow, including gofmt/go vet/go test/go test -race.
+5. The workflow regenerates `THIRD_PARTY_NOTICES.md` and fails if it is out of date.
+6. GoReleaser publishes the GitHub Release and uploads artifacts.
+7. After the release workflow succeeds, close the milestone.
 
 ## Branch strategy
 

--- a/README.md
+++ b/README.md
@@ -108,3 +108,7 @@ Releases are published by tagging a version and pushing it to GitHub.
 2. Push the tag to GitHub.
 3. GitHub Actions runs the release workflow (gofmt/go vet/go test/go test -race + third-party notices check).
 4. GoReleaser publishes the GitHub Release and uploads artifacts.
+
+Notes:
+- When a versioned milestone is complete, release using the same version number.
+- Close the milestone after the release workflow succeeds.


### PR DESCRIPTION
## Summary

Update the release workflow to lock GoReleaser and verify generated files before tests.

## What / Why

- Lock GoReleaser action to `~> v2` to avoid breaking changes.
- Run `go mod tidy`/`go generate` in the workflow and fail if they modify files.
- Document the milestone release/close ordering.

## Related issues

N/A

## Testing

Not run (workflow/docs changes only).

```bash
# not run
```

## Fix log

- 2026-01-10: initial workflow/docs update

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [ ] `go vet ./...`
- [ ] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
