### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/sh4869221b/go-nico-list/security/code-scanning/9](https://github.com/sh4869221b/go-nico-list/security/code-scanning/9)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions for this workflow. Since the job only checks out code and runs Go tooling (format, vet, tests) without modifying GitHub resources, it only needs read access to repository contents. The best fix is to add a `permissions:` block near the top of the workflow at the root level, so it applies to all jobs (including `go-ci`), and set `contents: read`. This follows the principle of least privilege and directly satisfies CodeQL’s recommendation.

Concretely: edit `.github/workflows/ci.yml` and insert a `permissions:` section after the `name: CI` line (or before `jobs:`), with `contents: read`. No changes to individual steps or additional imports are needed, and no new functionality is introduced—this only restricts what the automatically provided `GITHUB_TOKEN` may do.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
