### PR TITLE
test: remove redundant backoff test

### DIFF
--- a/internal/niconico/client_test.go
+++ b/internal/niconico/client_test.go
@@ -95,32 +95,6 @@ func TestRetriesRequest(t *testing.T) {
 	res.Body.Close()
 }
 
-func TestRetriesRequestBackoff(t *testing.T) {
-	retries := 3
-	count := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count++
-		if count < 3 {
-			w.WriteHeader(http.StatusInternalServerError)
-		} else {
-			w.WriteHeader(http.StatusOK)
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	res, err := retriesRequest(context.Background(), server.URL, time.Second, retries)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if res.StatusCode != http.StatusOK {
-		t.Errorf("expected status 200, got %d", res.StatusCode)
-	}
-	if count != 3 {
-		t.Errorf("expected 3 attempts, got %d", count)
-	}
-	res.Body.Close()
-}
-
 func TestRetriesRequestContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
## Summary

Remove the redundant backoff test to keep retry coverage focused and non-duplicative.

## What / Why

- Delete `TestRetriesRequestBackoff`, which duplicated `TestRetriesRequest` assertions.
- Backoff timing is not asserted here, so duplication only adds maintenance noise.

## Related issues

Closes #150

## Testing

```bash
gofmt -w internal/niconico/client_test.go
go vet ./...
go test ./...
GOTOOLCHAIN=go1.24.3 go test -race ./...
```

## Fix log

2026-01-11: remove redundant backoff test.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
