### PR TITLE
chore: tidy go.mod for release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,15 @@ module github.com/sh4869221b/go-nico-list
 
 go 1.24.3
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/spf13/cobra v1.10.2
+	golang.org/x/term v0.28.0
+)
 
 require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	golang.org/x/sys v0.29.0 // indirect
-	golang.org/x/term v0.28.0 // indirect
 )
 
 require (


### PR DESCRIPTION
## Summary

Align go.mod with `go mod tidy` output so the v0.23.0 release workflow passes cleanly.

## What / Why

The release workflow runs `go mod tidy` and failed because `golang.org/x/term` was indirect. This updates go.mod to match tidy output.

## Related issues

Closes #159

## Testing

```bash
go vet ./...
go test ./...
```

## Fix log

- 2026-01-11: tidy go.mod for release workflow

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [x] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係の構成を整理しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->