### PR TITLE
ci: reset go.sum before goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
         run: |
           bash scripts/gen-third-party-notices.sh
           git diff --exit-code -- THIRD_PARTY_NOTICES.md
+      - name: Reset go.sum before release
+        run: |
+          git restore --staged --worktree go.sum
+          git diff --exit-code -- go.sum
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
## Summary

Reset `go.sum` before GoReleaser so release workflows don't fail due to a dirty git state.

## What / Why

Some workflow steps reintroduce sums after `go mod tidy`, leaving the repo dirty. This restores `go.sum` right before GoReleaser runs.

## Related issues

Closes #163

## Testing

Not run (workflow change only).

## Fix log

- 2026-01-11: restore go.sum before goreleaser

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [ ] `go vet ./...`
- [ ] `go test ./...`
- [ ] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
