### PR TITLE
refactor: extract cli and retry helpers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -16,6 +16,12 @@ main.go
               └─ internal/niconico (domain: fetch/retry/sort)
 ```
 
+### Refactoring guardrails
+- Behavior and output must remain identical during refactors.
+- Refactors only change internal structure (function boundaries, helpers, file splits).
+- CLI/user-facing flags, outputs, logs, exit codes, and progress behavior are unchanged.
+- Domain API behavior (filters, pagination, retry/ratelimit semantics) is unchanged.
+
 ### Responsibilities
 - `main.go`:
   - Resolve version (build info / ldflags).


### PR DESCRIPTION
## What / Why
- Extract CLI validation, logger setup, and IO helpers to reduce duplication while keeping behavior unchanged.
- Refactor retry response handling to centralize status evaluation and backoff logic without changing semantics.

## Related issues
- Closes #171

## Testing
```bash
gofmt -w cmd/root.go internal/niconico/client.go
go vet ./...
go test ./...
```

## Fix log
- 2026-01-13: initial implementation

## Breaking change
- [ ] Yes
- [x] No

## Checklist
- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * HTTP再試行メカニズムを改善し、サーバーレスポンスヘッダーに基づく指数バックオフ処理を実装しました。
  * 内部システムの構造化を行い、コマンド実行フローを整理しました。
  * 既存の機能とAPI動作は変わりません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->