### PR TITLE
docs: add docstring policy and comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,13 @@ If the user-facing behavior changes, update `README.md` and `DESIGN.md`.
 If the idea is not finalized yet, keep it out of `DESIGN.md` and track it in a GitHub Issue.
 Keep `WORKLOG.md` local-only (git-ignored); do not commit it.
 
+## Docstring policy
+
+- Add docstrings for all non-test functions, methods, and types.
+- Start docstrings with the identifier name and keep them to a single sentence when possible.
+- Test functions (`Test*`, `Benchmark*`, `Example*`) are exempt.
+- Docstrings for `const`/`var` are optional; add them when intent is non-obvious.
+
 ## Pull requests
 
 - Keep diffs small and focused.

--- a/internal/niconico/nico_data.go
+++ b/internal/niconico/nico_data.go
@@ -4,6 +4,7 @@ import (
 	"time"
 )
 
+// NicoData represents the niconico API response payload.
 type NicoData struct {
 	Meta struct {
 		Status int `json:"status"`

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ var (
 	Version = "unset"
 )
 
+// main resolves version info, installs signal handling, and runs the CLI.
 func main() {
 	if Version == "unset" {
 		info, ok := debug.ReadBuildInfo()


### PR DESCRIPTION
## Summary

Document the docstring policy and add missing doc comments for non-test code.

## What / Why

Define a consistent docstring policy to reduce review noise and align existing code with it.

## Related issues

Closes #165

## Testing

```bash
gofmt -w main.go internal/niconico/client.go internal/niconico/nico_data.go cmd/root.go
go vet ./...
go test ./...
```

## Fix log


## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [x] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * APIリクエストのリトライとレート制限機能を追加し、より堅牢な通信処理を実現
  * JSON出力形式を拡張し、より詳細な情報を含める

* **ドキュメント**
  * ドキストリング政策セクションを追加
  * 関数のドキュメンテーションコメントを改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->