### PR TITLE
docs: require squash merge policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Baseline rules for changes in this repository.
 - If you modify Go files, run `gofmt -w <files>` (or `gofmt -w .` to format everything).
 - After changes, run `go vet ./...` and confirm there are no errors.
 - After changes, run `go test ./...` and confirm there are no errors.
-- Use short-lived branches (e.g. `feature/*`) and merge via PR; do not commit directly to `master` unless explicitly requested.
+- Use short-lived branches (e.g. `feature/*`) and merge via PR using **squash merge**; do not commit directly to `master` unless explicitly requested.
 - Use the `branch-helper` skill for tasks that modify the repository unless the user requests otherwise.
 - After addressing review feedback, ask Codex for a re-review in chat.
 - PRs must include an auto-close keyword for related issues (e.g. `Closes #123`).
@@ -22,7 +22,7 @@ Baseline rules for changes in this repository.
 ## Workflow Notes
 - Keep tests deterministic; avoid time-based ordering and use controllable IO (e.g. pipes) when sequencing matters.
 - When mocking the niconico API, ensure pagination terminates (e.g. return empty items or 404 for page > 1).
-- Avoid interactive editors in automated merges (use `git merge -m` or set `GIT_EDITOR` to a non-interactive command).
+- Avoid interactive editors in automated merges (use `gh pr merge --squash` and set `GIT_EDITOR` to a non-interactive command when needed).
 - Before merging, wait for all CI checks to complete (use `gh pr checks --watch`) unless explicitly told to skip.
 - When a versioned milestone is completed, release using the same version number; after the release workflow succeeds, close the milestone.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Keep `WORKLOG.md` local-only (git-ignored); do not commit it.
 ## Branch strategy
 
 - Use `master` as the only long-lived branch.
-- Create short-lived branches (e.g. `feature/*`) and merge via PR into `master`.
+- Create short-lived branches (e.g. `feature/*`) and merge via **squash PR** into `master`.
 - Tags for releases (`vX.Y.Z`) are cut from `master`.
 
 ## Review criteria

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -178,7 +178,7 @@ main.go
 
 ## Branch strategy
 - Use `master` as the only long-lived branch.
-- Create short-lived branches (e.g. `feature/*`) and merge via PR into `master`.
+- Create short-lived branches (e.g. `feature/*`) and merge via **squash PR** into `master`.
 - Releases are tagged from `master` (`vX.Y.Z`).
 
 ## Change Guidelines


### PR DESCRIPTION
## Summary

Require squash merge as the repository merge policy and align docs with the enforced setting.

## What / Why

- Update `AGENTS.md`, `CONTRIBUTING.md`, and `docs/DESIGN.md` to explicitly require squash merge for PRs into `master`.
- Replace workflow note from local `git merge -m` guidance to `gh pr merge --squash` guidance.
- Apply repository setting change so only squash merge is allowed (`allow_squash_merge=true`, `allow_merge_commit=false`, `allow_rebase_merge=false`).

## Related issues

Closes #178

## Testing

```bash
go vet ./...
go test ./...
```

## Fix log

- 2026-02-07: define squash merge policy in docs and enforce squash-only merge settings.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
