### PR TITLE
chore: adopt go-licenses for third-party notices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,9 @@ If your change updates dependencies (changes `go.mod` / `go.sum`), also update:
 bash scripts/gen-third-party-notices.sh
 ```
 
-Requires bash and network access to fetch module license metadata.
+The script uses `go-licenses` (pinned in the script) and excludes test-only dependencies by default.
+Set `GO_LICENSES_SAVE_PATH` when you also want to save license texts to a directory.
+Requires bash and network access.
 
 ## Project structure
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,32 +2,20 @@
 
 This project is licensed under the MIT License (see `LICENSE`).
 
-The following list covers third-party Go modules used by this repository (direct and transitive).
+The following list covers third-party Go dependencies used by this repository
+(excluding test-only dependencies by default).
 For each dependency, refer to the upstream license text via the reference link.
 
 Note: this is provided for convenience and is not legal advice.
 
 ## Dependencies
 
-| Module | Version | License | Reference |
+| Dependency | Version | License | Reference |
 | --- | --- | --- | --- |
-| github.com/chengxilo/virtualterm | v1.0.4 | Unknown (no LICENSE file found in module source at this version) | https://pkg.go.dev/github.com/chengxilo/virtualterm@v1.0.4?tab=licenses |
-| github.com/cpuguy83/go-md2man/v2 | v2.0.6 | MIT | https://pkg.go.dev/github.com/cpuguy83/go-md2man/v2@v2.0.6?tab=licenses |
-| github.com/davecgh/go-spew | v1.1.1 | ISC | https://pkg.go.dev/github.com/davecgh/go-spew@v1.1.1?tab=licenses |
-| github.com/inconshreveable/mousetrap | v1.1.0 | Apache-2.0 | https://pkg.go.dev/github.com/inconshreveable/mousetrap@v1.1.0?tab=licenses |
-| github.com/k0kubun/go-ansi | v0.0.0-20180517002512-3bf9e2903213 | MIT | https://pkg.go.dev/github.com/k0kubun/go-ansi@v0.0.0-20180517002512-3bf9e2903213?tab=licenses |
-| github.com/mattn/go-isatty | v0.0.20 | MIT | https://pkg.go.dev/github.com/mattn/go-isatty@v0.0.20?tab=licenses |
-| github.com/mattn/go-runewidth | v0.0.16 | MIT | https://pkg.go.dev/github.com/mattn/go-runewidth@v0.0.16?tab=licenses |
-| github.com/mitchellh/colorstring | v0.0.0-20190213212951-d06e56a500db | MIT | https://pkg.go.dev/github.com/mitchellh/colorstring@v0.0.0-20190213212951-d06e56a500db?tab=licenses |
-| github.com/pmezard/go-difflib | v1.0.0 | BSD-3-Clause | https://pkg.go.dev/github.com/pmezard/go-difflib@v1.0.0?tab=licenses |
-| github.com/rivo/uniseg | v0.4.7 | MIT | https://pkg.go.dev/github.com/rivo/uniseg@v0.4.7?tab=licenses |
-| github.com/russross/blackfriday/v2 | v2.1.0 | BSD-2-Clause | https://pkg.go.dev/github.com/russross/blackfriday/v2@v2.1.0?tab=licenses |
-| github.com/schollz/progressbar/v3 | v3.19.0 | MIT | https://pkg.go.dev/github.com/schollz/progressbar/v3@v3.19.0?tab=licenses |
-| github.com/spf13/cobra | v1.10.2 | Apache-2.0 | https://pkg.go.dev/github.com/spf13/cobra@v1.10.2?tab=licenses |
-| github.com/spf13/pflag | v1.0.9 | BSD-3-Clause | https://pkg.go.dev/github.com/spf13/pflag@v1.0.9?tab=licenses |
-| github.com/stretchr/testify | v1.9.0 | MIT | https://pkg.go.dev/github.com/stretchr/testify@v1.9.0?tab=licenses |
-| go.yaml.in/yaml/v3 | v3.0.4 | MIT OR Apache-2.0 | https://pkg.go.dev/go.yaml.in/yaml/v3@v3.0.4?tab=licenses |
-| golang.org/x/sys | v0.29.0 | BSD-3-Clause | https://pkg.go.dev/golang.org/x/sys@v0.29.0?tab=licenses |
-| golang.org/x/term | v0.28.0 | BSD-3-Clause | https://pkg.go.dev/golang.org/x/term@v0.28.0?tab=licenses |
-| gopkg.in/check.v1 | v0.0.0-20161208181325-20d25e280405 | BSD-2-Clause | https://pkg.go.dev/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405?tab=licenses |
-| gopkg.in/yaml.v3 | v3.0.1 | MIT OR Apache-2.0 | https://pkg.go.dev/gopkg.in/yaml.v3@v3.0.1?tab=licenses |
+| github.com/mitchellh/colorstring | v0.0.0-20190213212951-d06e56a500db | MIT | https://github.com/mitchellh/colorstring/blob/d06e56a500db/LICENSE |
+| github.com/rivo/uniseg | v0.4.7 | MIT | https://github.com/rivo/uniseg/blob/v0.4.7/LICENSE.txt |
+| github.com/schollz/progressbar/v3 | v3.19.0 | MIT | https://github.com/schollz/progressbar/blob/v3.19.0/LICENSE |
+| github.com/spf13/cobra | v1.10.2 | Apache-2.0 | https://github.com/spf13/cobra/blob/v1.10.2/LICENSE.txt |
+| github.com/spf13/pflag | v1.0.9 | BSD-3-Clause | https://github.com/spf13/pflag/blob/v1.0.9/LICENSE |
+| golang.org/x/sys/unix | v0.40.0 | BSD-3-Clause | https://cs.opensource.google/go/x/sys/+/v0.40.0:LICENSE |
+| golang.org/x/term | v0.39.0 | BSD-3-Clause | https://cs.opensource.google/go/x/term/+/v0.39.0:LICENSE |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -174,6 +174,8 @@ main.go
 - The release workflow verifies generated files (`go mod tidy`, `go generate ./...`).
 - The release workflow runs quality gates (gofmt, go vet, go test, go test -race).
 - `THIRD_PARTY_NOTICES.md` is kept in sync via `scripts/gen-third-party-notices.sh` and verified in CI.
+  - The script uses `go-licenses report` and excludes test-only dependencies by default.
+  - `GO_LICENSES_SAVE_PATH` can be set to export license texts with `go-licenses save`.
 - GoReleaser builds and publishes artifacts for supported OSes.
 
 ## Branch strategy


### PR DESCRIPTION
## Summary

Adopt `go-licenses` as the source of truth for `THIRD_PARTY_NOTICES.md` generation.

## What / Why

- Replaced the custom shell-based license detection with `go run github.com/google/go-licenses@v1.6.0 report`.
- Pinned the tool version via `GO_LICENSES_VERSION` (default: `v1.6.0`).
- Excluded test-only dependencies by default by generating notices from the build dependency graph (`./...`).
- Added optional `go-licenses save` integration via `GO_LICENSES_SAVE_PATH`.
- Prevented `go.sum` drift from this script by avoiding `go mod download` and running tool commands with `-mod=readonly` (when `GOFLAGS` does not already specify `-mod`).
- Updated docs and regenerated `THIRD_PARTY_NOTICES.md`.

## Related issues

Closes #121

## Testing

```bash
bash scripts/gen-third-party-notices.sh
go vet ./...
go test ./...
```

## Fix log

- 2026-02-07: replace custom detector with `go-licenses`, regenerate notices, and update docs.
- 2026-02-07: fix template newline rendering and remove `go mod download` to avoid `go.sum` drift.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [x] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
