### PR TITLE
test: add higher-level test layers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,24 @@ go vet ./...
 go test ./...
 ```
 
+## Optional test layers
+
+Use these opt-in commands when working on higher-level test coverage:
+
+```bash
+# Contract fixture decode checks
+go test ./internal/niconico -run TestNicoDataContract -count=1
+
+# Fuzz smoke run (short)
+go test ./... -run=^$ -fuzz=Fuzz -fuzztime=10s
+
+# E2E against real API (requires env var)
+GO_NICO_LIST_E2E_USER_ID=<user-id> go test -tags=e2e ./internal/niconico -run TestGetVideoListE2E -count=1
+
+# Bench baseline
+go test ./internal/niconico -run=^$ -bench=BenchmarkNiconicoSort -benchmem -count=1
+```
+
 ## Third-party notices
 
 If your change updates dependencies (changes `go.mod` / `go.sum`), run:

--- a/README.md
+++ b/README.md
@@ -108,6 +108,22 @@ GitHub Actions runs on every push and pull request (all branches) and enforces:
 - `go test -count=1 ./...`
 - `go test -race -count=1 ./...`
 
+## Test layers
+- Integration-style command wiring tests: `cmd/root_test.go` (`httptest` + stdout/stderr/exit-code checks).
+- Contract tests: `internal/niconico/nico_data_contract_test.go` (fixture decode from `internal/niconico/testdata/`).
+- Fuzz tests: `internal/niconico/fuzz_test.go`, `cmd/root_fuzz_test.go` (sorting/JSON/url-parse panic safety).
+- E2E tests (opt-in): `internal/niconico/e2e_test.go` with `-tags=e2e`.
+- Benchmarks (opt-in): `internal/niconico/benchmark_test.go`.
+
+Opt-in commands:
+
+```bash
+go test ./internal/niconico -run TestNicoDataContract -count=1
+go test ./... -run=^$ -fuzz=Fuzz -fuzztime=10s
+GO_NICO_LIST_E2E_USER_ID=<user-id> go test -tags=e2e ./internal/niconico -run TestGetVideoListE2E -count=1
+go test ./internal/niconico -run=^$ -bench=BenchmarkNiconicoSort -benchmem -count=1
+```
+
 ## Contributing
 See `CONTRIBUTING.md`.
 

--- a/cmd/root_fuzz_test.go
+++ b/cmd/root_fuzz_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"regexp"
+	"testing"
+)
+
+func FuzzUserIDFromMatchNoPanic(f *testing.F) {
+	re := regexp.MustCompile(`((http(s)?://)?(www\.)?)nicovideo\.jp/user/(?P<userID>\d{1,9})(/video)?`)
+	f.Add("https://www.nicovideo.jp/user/12345/video")
+	f.Add("nicovideo.jp/user/1")
+	f.Add("invalid")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		match := re.FindStringSubmatch(input)
+		_ = userIDFromMatch(match, re)
+	})
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -168,6 +168,10 @@ main.go
 ## Tests
 - CLI tests: `cmd/root_test.go` (validation, output, progress, logfile).
 - Domain tests: `internal/niconico/client_test.go` (fetch/retry/sort).
+- Contract test: `internal/niconico/nico_data_contract_test.go` validates fixture JSON decode into `NicoData`.
+- Fuzz tests: `internal/niconico/fuzz_test.go` and `cmd/root_fuzz_test.go` ensure sorting/JSON/url parsing paths do not panic.
+- E2E test (opt-in): `internal/niconico/e2e_test.go` is gated by `//go:build e2e` and `GO_NICO_LIST_E2E_USER_ID`.
+- Benchmark (opt-in): `internal/niconico/benchmark_test.go` provides a `NiconicoSort` baseline (`go test -bench`).
 
 ## Release process (CI)
 - Release is triggered by pushing a `vX.Y.Z` tag to GitHub.

--- a/internal/niconico/benchmark_test.go
+++ b/internal/niconico/benchmark_test.go
@@ -1,0 +1,19 @@
+package niconico
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkNiconicoSort(b *testing.B) {
+	base := make([]string, 1000)
+	for i := range base {
+		base[i] = fmt.Sprintf("sm%d", 1000-i)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		values := append([]string(nil), base...)
+		NiconicoSort(values, false, false)
+	}
+}

--- a/internal/niconico/e2e_test.go
+++ b/internal/niconico/e2e_test.go
@@ -1,0 +1,61 @@
+//go:build e2e
+
+package niconico
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetVideoListE2E(t *testing.T) {
+	userID := strings.TrimSpace(os.Getenv("GO_NICO_LIST_E2E_USER_ID"))
+	if userID == "" {
+		t.Skip("set GO_NICO_LIST_E2E_USER_ID to run e2e test")
+	}
+	if !regexp.MustCompile(`^\d{1,9}$`).MatchString(userID) {
+		t.Fatalf("GO_NICO_LIST_E2E_USER_ID must be 1-9 digits: %q", userID)
+	}
+
+	baseURL := strings.TrimSpace(os.Getenv("GO_NICO_LIST_E2E_BASE_URL"))
+	if baseURL == "" {
+		baseURL = "https://nvapi.nicovideo.jp/v3"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ids, err := GetVideoList(
+		ctx,
+		userID,
+		0,
+		time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC),
+		false,
+		false,
+		baseURL,
+		3,
+		10*time.Second,
+		nil,
+		1,
+		1,
+		logger,
+	)
+	if err != nil {
+		t.Fatalf("GetVideoList returned error: %v", err)
+	}
+	if len(ids) == 0 {
+		t.Fatalf("expected at least one id for user %s", userID)
+	}
+	for _, id := range ids {
+		if !strings.HasPrefix(id, "sm") {
+			t.Fatalf("unexpected video id format: %q", id)
+		}
+	}
+}

--- a/internal/niconico/fuzz_test.go
+++ b/internal/niconico/fuzz_test.go
@@ -1,0 +1,31 @@
+package niconico
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func FuzzNiconicoSortNoPanic(f *testing.F) {
+	f.Add("sm12\nsm3\nsm1", false, false)
+	f.Add(tabStr+urlStr+"sm2\n"+tabStr+urlStr+"sm10\n"+tabStr+urlStr+"sm1", true, true)
+
+	f.Fuzz(func(t *testing.T, raw string, tab bool, url bool) {
+		items := strings.Split(raw, "\n")
+		if len(items) > 256 {
+			items = items[:256]
+		}
+		values := append([]string(nil), items...)
+		NiconicoSort(values, tab, url)
+	})
+}
+
+func FuzzNicoDataUnmarshalNoPanic(f *testing.F) {
+	f.Add([]byte(`{"meta":{"status":200},"data":{"totalCount":0,"items":[]}}`))
+	f.Add([]byte(`{}`))
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		var payload NicoData
+		_ = json.Unmarshal(b, &payload)
+	})
+}

--- a/internal/niconico/nico_data_contract_test.go
+++ b/internal/niconico/nico_data_contract_test.go
@@ -1,0 +1,44 @@
+package niconico
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNicoDataContract(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "nvapi_user_videos_page1.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var payload NicoData
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	if payload.Meta.Status != http.StatusOK {
+		t.Fatalf("meta.status: got %d, want %d", payload.Meta.Status, http.StatusOK)
+	}
+	if payload.Data.TotalCount != 2 {
+		t.Fatalf("data.totalCount: got %d, want 2", payload.Data.TotalCount)
+	}
+	if len(payload.Data.Items) != 2 {
+		t.Fatalf("data.items length: got %d, want 2", len(payload.Data.Items))
+	}
+
+	first := payload.Data.Items[0].Essential
+	if first.ID != "sm9" {
+		t.Fatalf("first id: got %q, want %q", first.ID, "sm9")
+	}
+	if first.Count.Comment != 12 {
+		t.Fatalf("first comment count: got %d, want 12", first.Count.Comment)
+	}
+	wantFirstRegisteredAt := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	if !first.RegisteredAt.Equal(wantFirstRegisteredAt) {
+		t.Fatalf("first registeredAt: got %s, want %s", first.RegisteredAt.Format(time.RFC3339), wantFirstRegisteredAt.Format(time.RFC3339))
+	}
+}

--- a/internal/niconico/testdata/nvapi_user_videos_page1.json
+++ b/internal/niconico/testdata/nvapi_user_videos_page1.json
@@ -1,0 +1,84 @@
+{
+  "meta": {
+    "status": 200
+  },
+  "data": {
+    "totalCount": 2,
+    "items": [
+      {
+        "essential": {
+          "type": "video",
+          "id": "sm9",
+          "title": "sample title 1",
+          "registeredAt": "2025-01-02T03:04:05Z",
+          "count": {
+            "view": 100,
+            "comment": 12,
+            "mylist": 3,
+            "like": 8
+          },
+          "thumbnail": {
+            "url": "https://example.invalid/thumb1.jpg",
+            "middleUrl": "https://example.invalid/thumb1-m.jpg",
+            "largeUrl": "https://example.invalid/thumb1-l.jpg",
+            "listingUrl": "https://example.invalid/thumb1-s.jpg",
+            "nHdUrl": "https://example.invalid/thumb1-hd.jpg"
+          },
+          "duration": 120,
+          "shortDescription": "desc",
+          "latestCommentSummary": "summary",
+          "isChannelVideo": false,
+          "isPaymentRequired": false,
+          "playbackPosition": null,
+          "owner": {
+            "ownerType": "user",
+            "id": "1",
+            "name": "owner-1",
+            "iconUrl": "https://example.invalid/icon1.png"
+          },
+          "requireSensitiveMasking": false,
+          "videoLive": null,
+          "9d091f87": false,
+          "acf68865": false
+        }
+      },
+      {
+        "essential": {
+          "type": "video",
+          "id": "sm10",
+          "title": "sample title 2",
+          "registeredAt": "2025-01-03T04:05:06Z",
+          "count": {
+            "view": 200,
+            "comment": 34,
+            "mylist": 5,
+            "like": 13
+          },
+          "thumbnail": {
+            "url": "https://example.invalid/thumb2.jpg",
+            "middleUrl": "https://example.invalid/thumb2-m.jpg",
+            "largeUrl": "https://example.invalid/thumb2-l.jpg",
+            "listingUrl": "https://example.invalid/thumb2-s.jpg",
+            "nHdUrl": "https://example.invalid/thumb2-hd.jpg"
+          },
+          "duration": 240,
+          "shortDescription": "desc-2",
+          "latestCommentSummary": "summary-2",
+          "isChannelVideo": false,
+          "isPaymentRequired": false,
+          "playbackPosition": null,
+          "owner": {
+            "ownerType": "user",
+            "id": "2",
+            "name": "owner-2",
+            "iconUrl": "https://example.invalid/icon2.png"
+          },
+          "requireSensitiveMasking": false,
+          "videoLive": null,
+          "9d091f87": false,
+          "acf68865": false
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Add higher-level test layers (contract/fuzz/e2e/benchmark) and document how to run them.

## What / Why

- Added a contract test with a representative API fixture to verify `NicoData` decode compatibility.
- Added fuzz tests to ensure URL parsing, sorting, and JSON handling paths do not panic.
- Added an opt-in E2E test (`//go:build e2e`) that hits the real API only when `GO_NICO_LIST_E2E_USER_ID` is set.
- Added a benchmark baseline for `NiconicoSort`.
- Updated `README.md`, `CONTRIBUTING.md`, and `docs/DESIGN.md` with test-layer guidance and commands.

## Related issues

Closes #114

## Testing

```bash
gofmt -w internal/niconico/nico_data_contract_test.go internal/niconico/fuzz_test.go internal/niconico/benchmark_test.go internal/niconico/e2e_test.go cmd/root_fuzz_test.go
go vet ./...
go test ./...
go test -race ./...

# optional layers
go test ./internal/niconico -run TestNicoDataContract -count=1
cache_dir="$(pwd)/.cache" && export GOCACHE="$cache_dir/go-build" GOMODCACHE="$cache_dir/gomod" GOPATH="$cache_dir/go" && mkdir -p "$GOCACHE" "$GOMODCACHE" "$GOPATH" && go test ./cmd -run=^$ -fuzz=FuzzUserIDFromMatchNoPanic -fuzztime=3s
go test ./internal/niconico -run=^$ -fuzz=FuzzNiconicoSortNoPanic -fuzztime=3s
go test ./internal/niconico -run=^$ -bench=BenchmarkNiconicoSort -benchmem -count=1
go test -tags=e2e ./internal/niconico -run TestGetVideoListE2E -count=1
```

## Fix log

- 2026-02-07: add contract/fuzz/e2e/benchmark test layers and update docs.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
