### PR TITLE
docs: enforce one-issue-per-change rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Baseline rules for changes in this repository.
 - Before opening a PR, verify generated-file drift checks stay clean: `go mod tidy`, `go generate ./...`, and `git diff --exit-code`.
 - If dependencies changed (`go.mod` / `go.sum`), run `bash scripts/gen-third-party-notices.sh` and ensure no drift in `THIRD_PARTY_NOTICES.md`.
 - Before implementation, create (or confirm) a GitHub Issue that tracks the work.
+- Keep issue scope atomic: one issue must map to one fix or one feature.
 - Use short-lived branches (e.g. `feature/*`) and merge via PR using **squash merge**; do not commit directly to `master` unless explicitly requested.
 - Implement only on the issue branch and merge via PR; never push implementation commits directly to `master`.
 - Use the `branch-helper` skill for tasks that modify the repository unless the user requests otherwise.


### PR DESCRIPTION
## Summary

Add an explicit operations rule that one issue must map to one fix or one feature.

## What / Why

- Updated `AGENTS.md` development checklist to require atomic issue scope.
- This aligns day-to-day execution with the requested workflow policy and improves traceability.

## Related issues

Closes #190

## Testing

```bash
not run (docs-only change)
```

## Fix log

- 2026-02-07: Added one-issue-per-change rule to `AGENTS.md`.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .` (not required: no Go files changed)
- [ ] `go vet ./...` (not required: no Go files changed)
- [ ] `go test ./...` (not required: no Go files changed)
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed (not required)
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed (not required)
