### PR TITLE
fix: validate timeout lower bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Notes:
 - Inputs can be provided via arguments, `--input-file`, and `--stdin` (newline-separated).
 - Each input must contain `nicovideo.jp/user/<id>` (scheme optional). Plain digits or `user/<id>` without the domain are treated as invalid inputs and skipped.
 - Results are written to stdout; progress and logs are written to stderr. Use `--logfile` to redirect logs to a file.
-- Setting `concurrency` or `retries` to a value less than 1 will cause a runtime error.
+- Setting `concurrency` or `retries` to a value less than 1, or `timeout` to a value less than or equal to 0, will cause a runtime error.
 - `--max-pages` and `--max-videos` are safety caps; `0` disables them.
 - When a safety cap is hit, fetching stops early and returns best-effort results without error.
 - Responses with HTTP status other than 200/404 after retries are treated as fetch errors.

--- a/cmd/root_run.go
+++ b/cmd/root_run.go
@@ -28,6 +28,9 @@ func validateFlags() error {
 	if retries < 1 {
 		return errors.New("retries must be at least 1")
 	}
+	if httpClientTimeout <= 0 {
+		return errors.New("timeout must be greater than 0")
+	}
 	if rateLimit < 0 {
 		return errors.New("rate-limit must be at least 0")
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -54,6 +54,21 @@ func TestRateLimitValidation(t *testing.T) {
 	}
 }
 
+func TestTimeoutValidation(t *testing.T) {
+	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	dateafter = "10000101"
+	datebefore = "99991231"
+	oldTimeout := httpClientTimeout
+	t.Cleanup(func() { httpClientTimeout = oldTimeout })
+
+	for _, timeout := range []time.Duration{0, -time.Second} {
+		httpClientTimeout = timeout
+		if err := runRootCmd(nil, []string{"nicovideo.jp/user/1"}); err == nil || err.Error() != "timeout must be greater than 0" {
+			t.Fatalf("unexpected error for timeout %v: %v", timeout, err)
+		}
+	}
+}
+
 func TestMinIntervalValidation(t *testing.T) {
 	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	dateafter = "10000101"

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -107,7 +107,7 @@ main.go
 3. Aggregate and sort raw IDs, apply optional `tab/url` formatting, then print to stdout.
 
 ## Errors and Exit Codes
-- Validation errors (`concurrency`/`retries`/date format): **non-zero exit**.
+- Validation errors (`concurrency`/`retries`/`timeout`/date format): **non-zero exit**.
   - Print **only the error message** to stderr; no usage output.
 - If any fetch errors occur: **log all errors** to the log destination and still output any retrieved IDs, exit **non-zero**.
   - Errors include HTTP/IO/JSON failures from fetch operations.


### PR DESCRIPTION
## Summary

Validate `--timeout` as strictly greater than zero.

## What / Why

- Added timeout lower-bound validation in `validateFlags`.
- Added tests for `timeout=0` and negative timeout values.
- Updated docs to reflect timeout validation behavior.

## Related issues

Closes #192

## Testing

```bash
go vet ./...
go test ./...
go test -race ./...
```

## Fix log

- 2026-02-07: Added timeout validation and tests.
- 2026-02-07: Updated README/DESIGN docs for timeout constraints.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .` (not required: gofmt clean)
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed (not required)
