### PR TITLE
docs: document input line length limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ cat users.txt | go-nico-list --stdin
 
 Notes:
 - Inputs can be provided via arguments, `--input-file`, and `--stdin` (newline-separated).
+- Input lines from `--input-file` and `--stdin` are limited to 1 MiB per line; longer lines fail with an input read error.
 - Each input must contain `nicovideo.jp/user/<id>` (scheme optional). Plain digits or `user/<id>` without the domain are treated as invalid inputs and skipped.
 - Results are written to stdout; progress and logs are written to stderr. Use `--logfile` to redirect logs to a file.
 - Setting `concurrency` or `retries` to a value less than 1, or `timeout` to a value less than or equal to 0, will cause a runtime error.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -51,6 +51,7 @@ main.go
   - Regex is **partial match** (valid if the input contains a match).
   - If multiple matches exist, use the **first `nicovideo.jp/user/<id>`**.
   - `user/<id>` without the domain and plain digits are treated as invalid inputs.
+  - Input lines read from `--input-file` or `--stdin` are limited to 1 MiB per line (`bufio.Scanner` limit); longer lines return an input read error.
 - Flags:
   - `--comment` (default `0`): minimum comment count.
   - `--dateafter` (default `10000101`) / `--datebefore` (default `99991231`): `YYYYMMDD`.


### PR DESCRIPTION
## Summary

Document the input line length limit (1 MiB per line) for `--input-file` and `--stdin`.

## What / Why

- Added README note about the per-line scanner limit.
- Added DESIGN note to keep behavior traceable to implementation.

## Related issues

Closes #196

## Testing

```bash
not run (docs-only change)
```

## Fix log

- 2026-02-07: Documented 1 MiB per-line input limit and error behavior.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .` (not required: no Go files changed)
- [ ] `go vet ./...` (not required: no Go files changed)
- [ ] `go test ./...` (not required: no Go files changed)
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed (not required)
