### PR TITLE
test: assert required request headers

### DIFF
--- a/internal/niconico/client_test.go
+++ b/internal/niconico/client_test.go
@@ -85,6 +85,12 @@ func TestRetriesRequest(t *testing.T) {
 	retries := 3
 	count := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Frontend-Id"); got != "6" {
+			t.Fatalf("unexpected X-Frontend-Id header: %q", got)
+		}
+		if got := r.Header.Get("Accept"); got != "*/*" {
+			t.Fatalf("unexpected Accept header: %q", got)
+		}
 		count++
 		if count < 3 {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/internal/niconico/client_test.go
+++ b/internal/niconico/client_test.go
@@ -3,6 +3,7 @@ package niconico
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -84,12 +85,18 @@ func TestCloseAndIsNotFound(t *testing.T) {
 func TestRetriesRequest(t *testing.T) {
 	retries := 3
 	count := 0
+	var headerErrs []string
+	var headerErrsMu sync.Mutex
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("X-Frontend-Id"); got != "6" {
-			t.Fatalf("unexpected X-Frontend-Id header: %q", got)
+			headerErrsMu.Lock()
+			headerErrs = append(headerErrs, fmt.Sprintf("unexpected X-Frontend-Id header: %q", got))
+			headerErrsMu.Unlock()
 		}
 		if got := r.Header.Get("Accept"); got != "*/*" {
-			t.Fatalf("unexpected Accept header: %q", got)
+			headerErrsMu.Lock()
+			headerErrs = append(headerErrs, fmt.Sprintf("unexpected Accept header: %q", got))
+			headerErrsMu.Unlock()
 		}
 		count++
 		if count < 3 {
@@ -109,6 +116,11 @@ func TestRetriesRequest(t *testing.T) {
 	}
 	if count != 3 {
 		t.Errorf("expected 3 attempts, got %d", count)
+	}
+	headerErrsMu.Lock()
+	defer headerErrsMu.Unlock()
+	if len(headerErrs) > 0 {
+		t.Fatalf("header assertions failed: %v", headerErrs)
 	}
 	res.Body.Close()
 }


### PR DESCRIPTION
## Summary

Add header contract assertions for requests made by `retriesRequest`.

## What / Why

- Added explicit assertions for required headers in `TestRetriesRequest`:
  - `X-Frontend-Id: 6`
  - `Accept: */*`
- Prevents silent regressions in API request contract.

## Related issues

Closes #201

## Testing

```bash
go test ./internal/niconico -run TestRetriesRequest -count=1
go vet ./...
go test ./...
go test -race ./...
```

## Fix log

- 2026-02-07: Added request header assertions in client tests.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .` (not required: gofmt clean)
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Updated docs (`README.md` / `DESIGN.md`) if behavior changed (not required)
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed (not required)
