### PR TITLE
test: cover date format validation errors

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -85,6 +85,38 @@ func TestDateRangeOrderValidation(t *testing.T) {
 	}
 }
 
+func TestDateAfterFormatValidation(t *testing.T) {
+	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	oldAfter := dateafter
+	oldBefore := datebefore
+	dateafter = "2025-01-01"
+	datebefore = "20250101"
+	t.Cleanup(func() {
+		dateafter = oldAfter
+		datebefore = oldBefore
+	})
+
+	if err := runRootCmd(nil, []string{"nicovideo.jp/user/1"}); err == nil || err.Error() != "dateafter format error" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDateBeforeFormatValidation(t *testing.T) {
+	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	oldAfter := dateafter
+	oldBefore := datebefore
+	dateafter = "20250101"
+	datebefore = "2025-01-01"
+	t.Cleanup(func() {
+		dateafter = oldAfter
+		datebefore = oldBefore
+	})
+
+	if err := runRootCmd(nil, []string{"nicovideo.jp/user/1"}); err == nil || err.Error() != "datebefore format error" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestDateRangeSameDayAllowed(t *testing.T) {
 	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	oldAfter := dateafter


### PR DESCRIPTION
## Summary

Add direct tests for date format validation errors.

## What / Why

- Added test for invalid `dateafter` format returning `dateafter format error`.
- Added test for invalid `datebefore` format returning `datebefore format error`.
- Strengthens regression detection for explicit format validation paths.

## Related issues

Closes #202

## Testing

```bash
go test ./cmd -run 'TestDate(After|Before|Range)' -count=1
go vet ./...
go test ./...
go test -race ./...
```

## Fix log

- 2026-02-07: Added date format validation tests for both bounds.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .` (not required: gofmt clean)
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Updated docs (`README.md` / `DESIGN.md`) if behavior changed (not required)
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed (not required)
