### PR TITLE
build: upgrade Go version to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sh4869221b/go-nico-list
 
-go 1.24.3
+go 1.26.0
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
## Summary

Bump the repository Go version to the latest stable release (`1.26.0`).

## What / Why

- Updated `go.mod` from `go 1.24.3` to `go 1.26.0`.
- This aligns local/CI builds with the latest stable Go release published on `go.dev`.
- No user-facing behavior changes.

## Related issues

Closes #208

## Testing

```bash
gofmt -w $(git ls-files '*.go')
go vet ./...
go test ./...
go test -race ./...
go mod tidy
go generate ./...
bash scripts/gen-third-party-notices.sh
```

## Fix log

- 2026-02-11: Updated `go.mod` Go version to `1.26.0` and re-ran required checks.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [x] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
