### PR TITLE
AddLatestDepsCI

### DIFF
--- a/.github/workflows/latest-deps-ci.yml
+++ b/.github/workflows/latest-deps-ci.yml
@@ -1,0 +1,46 @@
+name: Latest Deps CI
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  latest-deps-go-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Download deps
+        run: go mod download
+
+      - name: Update dependencies to latest (CI only)
+        run: go get -u -t ./...
+
+      - name: Tidy modules after update
+        run: go mod tidy
+
+      - name: Check gofmt
+        run: |
+          gofmt -w $(git ls-files '*.go')
+          git diff --exit-code -- '*.go'
+
+      - name: Go vet
+        run: go vet ./...
+
+      - name: Go build
+        run: go build ./...
+
+      - name: Go test
+        run: go test -count=1 ./...
+
+      - name: Go test (race)
+        run: go test -race -count=1 ./...


### PR DESCRIPTION
### Motivation

- 依存先の破壊的変更を早期検知するため、最新依存関係に更新した状態でのビルド・テストを既存CIとは別に自動で検証するワークフローを追加します。
- `go.mod` / `go.sum` の変更はリポジトリに残さずランナー内だけで試す運用とします。

### Description

- 追加ファイル: `.github/workflows/latest-deps-ci.yml` を追加して専用ワークフローを導入しました。 
- トリガーは `workflow_dispatch` と `schedule`（毎日1回、UTC 0:00）で、`push` / `pull_request` の通常CIとは分離しています。 
- Go セットアップは既存CIと同じ `actions/setup-go` を `go-version-file: go.mod` 指定で再利用しています。 
- CI内で `go get -u -t ./...` と `go mod tidy` で依存を一時的に最新化し、その後 `gofmt`、`go vet`、`go build`、`go test`、`go test -race` を個別ステップで実行する構成としました（`go.mod` の変更はコミットしません）。

### Testing

- `go vet ./...` を実行して成功しました。 
- `go test ./...` を実行して成功しました。 
- `go test -race ./...` を実行して成功しました。 
- `go mod tidy && go generate ./... && git diff --exit-code` を実行して差分が出ないことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0033890f4832385f8a44e5a9213c1)