### PR TITLE
test: tighten review follow-up coverage

### DIFF
--- a/cmd/root_fuzz_test.go
+++ b/cmd/root_fuzz_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 )
@@ -66,6 +67,9 @@ func FuzzSubmatchByNameNoPanic(f *testing.F) {
 		}
 
 		match := make([]string, int(matchLen%16))
+		for i := range match {
+			match[i] = fmt.Sprintf("capture-%d", i)
+		}
 		got := submatchByName(match, re, name)
 		idx := re.SubexpIndex(name)
 		if idx < 0 || idx >= len(match) {

--- a/cmd/root_fuzz_test.go
+++ b/cmd/root_fuzz_test.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "testing"
+import (
+	"regexp"
+	"testing"
+)
 
 func FuzzParseInputTargetNoPanic(f *testing.F) {
 	f.Add("https://www.nicovideo.jp/user/12345/video")
@@ -9,6 +12,70 @@ func FuzzParseInputTargetNoPanic(f *testing.F) {
 	f.Add("invalid")
 
 	f.Fuzz(func(t *testing.T, input string) {
-		_, _ = parseInputTarget(input)
+		target, ok := parseInputTarget(input)
+		if !ok {
+			if userInputPattern.MatchString(input) || mylistInputPattern.MatchString(input) {
+				t.Fatalf("expected parser to accept %q", input)
+			}
+			return
+		}
+
+		switch target.Type {
+		case targetTypeUser:
+			match := userInputPattern.FindStringSubmatch(input)
+			if len(match) == 0 {
+				t.Fatalf("expected %q to match the user input pattern", input)
+			}
+			want := submatchByName(match, userInputPattern, "userID")
+			if target.ID != want {
+				t.Fatalf("expected parsed user id %q, got %q for %q", want, target.ID, input)
+			}
+		case targetTypeMylist:
+			match := mylistInputPattern.FindStringSubmatch(input)
+			if len(match) == 0 {
+				t.Fatalf("expected %q to match the mylist input pattern", input)
+			}
+			want := submatchByName(match, mylistInputPattern, "mylistID")
+			if target.ID != want {
+				t.Fatalf("expected parsed mylist id %q, got %q for %q", want, target.ID, input)
+			}
+		default:
+			t.Fatalf("unexpected target type %q", target.Type)
+		}
+		if target.ID == "" {
+			t.Fatalf("expected parsed target to include an id for %q", input)
+		}
+	})
+}
+
+func FuzzSubmatchByNameNoPanic(f *testing.F) {
+	f.Add(uint8(0), "userID", uint8(0))
+	f.Add(uint8(0), "userID", uint8(1))
+	f.Add(uint8(1), "mylistID", uint8(3))
+	f.Add(uint8(2), "missing", uint8(4))
+
+	f.Fuzz(func(t *testing.T, patternKind uint8, name string, matchLen uint8) {
+		var re *regexp.Regexp
+		switch patternKind % 3 {
+		case 0:
+			re = userInputPattern
+		case 1:
+			re = mylistInputPattern
+		default:
+			re = regexp.MustCompile(`(plain)(pattern)`)
+		}
+
+		match := make([]string, int(matchLen%16))
+		got := submatchByName(match, re, name)
+		idx := re.SubexpIndex(name)
+		if idx < 0 || idx >= len(match) {
+			if got != "" {
+				t.Fatalf("expected empty submatch for idx=%d len=%d, got %q", idx, len(match), got)
+			}
+			return
+		}
+		if got != match[idx] {
+			t.Fatalf("expected match[%d]=%q, got %q", idx, match[idx], got)
+		}
 	})
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -813,6 +813,8 @@ func TestRunRootCmdJSONOutputUsersSortedByUserID(t *testing.T) {
 	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	dateafter = "10000101"
 	datebefore = "99991231"
+	user2Served := make(chan struct{})
+	var user2ServedOnce sync.Once
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -821,10 +823,16 @@ func TestRunRootCmdJSONOutputUsersSortedByUserID(t *testing.T) {
 			return
 		}
 		if strings.Contains(r.URL.Path, "/users/1/") {
-			time.Sleep(40 * time.Millisecond)
+			select {
+			case <-user2Served:
+			case <-r.Context().Done():
+				http.Error(w, "request canceled before user 2 response", http.StatusGatewayTimeout)
+				return
+			}
 			_, _ = io.WriteString(w, `{"data":{"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
 			return
 		}
+		user2ServedOnce.Do(func() { close(user2Served) })
 		_, _ = io.WriteString(w, `{"data":{"items":[{"essential":{"id":"sm2","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
 	}))
 	t.Cleanup(server.Close)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -813,26 +813,29 @@ func TestRunRootCmdJSONOutputUsersSortedByUserID(t *testing.T) {
 	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	dateafter = "10000101"
 	datebefore = "99991231"
-	user2Served := make(chan struct{})
-	var user2ServedOnce sync.Once
+	user2Completed := make(chan struct{})
+	var user2CompletedOnce sync.Once
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		isUser2 := strings.Contains(r.URL.Path, "/users/2/")
 		if r.URL.Query().Get("page") != "1" {
+			if isUser2 {
+				user2CompletedOnce.Do(func() { close(user2Completed) })
+			}
 			_, _ = io.WriteString(w, `{"data":{"items":[]}}`)
 			return
 		}
 		if strings.Contains(r.URL.Path, "/users/1/") {
 			select {
-			case <-user2Served:
+			case <-user2Completed:
 			case <-r.Context().Done():
-				http.Error(w, "request canceled before user 2 response", http.StatusGatewayTimeout)
+				http.Error(w, "request canceled before user 2 completed", http.StatusGatewayTimeout)
 				return
 			}
 			_, _ = io.WriteString(w, `{"data":{"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
 			return
 		}
-		user2ServedOnce.Do(func() { close(user2Served) })
 		_, _ = io.WriteString(w, `{"data":{"items":[{"essential":{"id":"sm2","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
 	}))
 	t.Cleanup(server.Close)

--- a/internal/niconico/benchmark_test.go
+++ b/internal/niconico/benchmark_test.go
@@ -10,10 +10,14 @@ func BenchmarkNiconicoSort(b *testing.B) {
 	for i := range base {
 		base[i] = fmt.Sprintf("sm%d", 1000-i)
 	}
+	values := make([]string, len(base))
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		values := append([]string(nil), base...)
+		b.StopTimer()
+		copy(values, base)
+		b.StartTimer()
 		NiconicoSort(values)
 	}
 }

--- a/internal/niconico/e2e_test.go
+++ b/internal/niconico/e2e_test.go
@@ -41,8 +41,8 @@ func TestGetVideoListE2E(t *testing.T) {
 		3,
 		10*time.Second,
 		nil,
-		1,
-		1,
+		2,
+		10,
 		logger,
 	)
 	if err != nil {
@@ -51,8 +51,13 @@ func TestGetVideoListE2E(t *testing.T) {
 	if len(ids) == 0 {
 		t.Fatalf("expected at least one id for user %s", userID)
 	}
+	if len(ids) > 10 {
+		t.Fatalf("expected at most 10 ids due to maxVideos cap, got %d", len(ids))
+	}
+
+	videoIDPattern := regexp.MustCompile(`^(sm|so|nm)\d+$`)
 	for _, id := range ids {
-		if !strings.HasPrefix(id, "sm") {
+		if !videoIDPattern.MatchString(id) {
 			t.Fatalf("unexpected video id format: %q", id)
 		}
 	}

--- a/internal/niconico/nico_data_contract_test.go
+++ b/internal/niconico/nico_data_contract_test.go
@@ -31,14 +31,116 @@ func TestNicoDataContract(t *testing.T) {
 	}
 
 	first := payload.Data.Items[0].Essential
+	if first.Type != "video" {
+		t.Fatalf("first type: got %q, want %q", first.Type, "video")
+	}
 	if first.ID != "sm9" {
 		t.Fatalf("first id: got %q, want %q", first.ID, "sm9")
+	}
+	if first.Title != "sample title 1" {
+		t.Fatalf("first title: got %q, want %q", first.Title, "sample title 1")
+	}
+	if first.Count.View != 100 {
+		t.Fatalf("first view count: got %d, want 100", first.Count.View)
 	}
 	if first.Count.Comment != 12 {
 		t.Fatalf("first comment count: got %d, want 12", first.Count.Comment)
 	}
+	if first.Count.Mylist != 3 {
+		t.Fatalf("first mylist count: got %d, want 3", first.Count.Mylist)
+	}
+	if first.Count.Like != 8 {
+		t.Fatalf("first like count: got %d, want 8", first.Count.Like)
+	}
 	wantFirstRegisteredAt := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
 	if !first.RegisteredAt.Equal(wantFirstRegisteredAt) {
 		t.Fatalf("first registeredAt: got %s, want %s", first.RegisteredAt.Format(time.RFC3339), wantFirstRegisteredAt.Format(time.RFC3339))
+	}
+	if first.Owner.OwnerType != "user" || first.Owner.ID != "1" || first.Owner.Name != "owner-1" {
+		t.Fatalf("unexpected first owner payload: %+v", first.Owner)
+	}
+	if first.Owner.IconURL != "https://example.invalid/icon1.png" {
+		t.Fatalf("first owner icon url: got %q, want %q", first.Owner.IconURL, "https://example.invalid/icon1.png")
+	}
+	if first.Thumbnail.URL != "https://example.invalid/thumb1.jpg" {
+		t.Fatalf("first thumbnail url: got %q, want %q", first.Thumbnail.URL, "https://example.invalid/thumb1.jpg")
+	}
+	if first.Thumbnail.MiddleURL != "https://example.invalid/thumb1-m.jpg" {
+		t.Fatalf("first thumbnail middleUrl: got %q, want %q", first.Thumbnail.MiddleURL, "https://example.invalid/thumb1-m.jpg")
+	}
+	if first.Thumbnail.LargeURL != "https://example.invalid/thumb1-l.jpg" {
+		t.Fatalf("first thumbnail largeUrl: got %q, want %q", first.Thumbnail.LargeURL, "https://example.invalid/thumb1-l.jpg")
+	}
+	if first.Thumbnail.ListingURL != "https://example.invalid/thumb1-s.jpg" {
+		t.Fatalf("first thumbnail listingUrl: got %q, want %q", first.Thumbnail.ListingURL, "https://example.invalid/thumb1-s.jpg")
+	}
+	if first.Thumbnail.NHdURL != "https://example.invalid/thumb1-hd.jpg" {
+		t.Fatalf("first thumbnail nHdUrl: got %q, want %q", first.Thumbnail.NHdURL, "https://example.invalid/thumb1-hd.jpg")
+	}
+	if first.Duration != 120 {
+		t.Fatalf("first duration: got %d, want 120", first.Duration)
+	}
+	if first.ShortDescription != "desc" || first.LatestCommentSummary != "summary" {
+		t.Fatalf("unexpected first text fields: short=%q summary=%q", first.ShortDescription, first.LatestCommentSummary)
+	}
+	if first.IsChannelVideo || first.IsPaymentRequired || first.RequireSensitiveMasking {
+		t.Fatalf("unexpected first boolean flags: channel=%t payment=%t masking=%t", first.IsChannelVideo, first.IsPaymentRequired, first.RequireSensitiveMasking)
+	}
+	if first.PlaybackPosition != nil || first.VideoLive != nil {
+		t.Fatalf("expected first playback/videoLive to be nil, got %#v %#v", first.PlaybackPosition, first.VideoLive)
+	}
+	if first.NineD091F87 || first.Acf68865 {
+		t.Fatalf("unexpected first feature flags: 9d091f87=%t acf68865=%t", first.NineD091F87, first.Acf68865)
+	}
+
+	second := payload.Data.Items[1].Essential
+	if second.Type != "video" {
+		t.Fatalf("second type: got %q, want %q", second.Type, "video")
+	}
+	if second.ID != "sm10" {
+		t.Fatalf("second id: got %q, want %q", second.ID, "sm10")
+	}
+	if second.Title != "sample title 2" {
+		t.Fatalf("second title: got %q, want %q", second.Title, "sample title 2")
+	}
+	if second.Count.View != 200 || second.Count.Comment != 34 || second.Count.Mylist != 5 || second.Count.Like != 13 {
+		t.Fatalf("unexpected second counts: %+v", second.Count)
+	}
+	wantSecondRegisteredAt := time.Date(2025, 1, 3, 4, 5, 6, 0, time.UTC)
+	if !second.RegisteredAt.Equal(wantSecondRegisteredAt) {
+		t.Fatalf("second registeredAt: got %s, want %s", second.RegisteredAt.Format(time.RFC3339), wantSecondRegisteredAt.Format(time.RFC3339))
+	}
+	if second.Owner.OwnerType != "user" || second.Owner.ID != "2" || second.Owner.Name != "owner-2" {
+		t.Fatalf("unexpected second owner payload: %+v", second.Owner)
+	}
+	if second.Owner.IconURL != "https://example.invalid/icon2.png" {
+		t.Fatalf("second owner icon url: got %q, want %q", second.Owner.IconURL, "https://example.invalid/icon2.png")
+	}
+	if second.Thumbnail.URL != "https://example.invalid/thumb2.jpg" {
+		t.Fatalf("second thumbnail url: got %q, want %q", second.Thumbnail.URL, "https://example.invalid/thumb2.jpg")
+	}
+	if second.Thumbnail.MiddleURL != "https://example.invalid/thumb2-m.jpg" {
+		t.Fatalf("second thumbnail middleUrl: got %q, want %q", second.Thumbnail.MiddleURL, "https://example.invalid/thumb2-m.jpg")
+	}
+	if second.Thumbnail.LargeURL != "https://example.invalid/thumb2-l.jpg" {
+		t.Fatalf("second thumbnail largeUrl: got %q, want %q", second.Thumbnail.LargeURL, "https://example.invalid/thumb2-l.jpg")
+	}
+	if second.Thumbnail.ListingURL != "https://example.invalid/thumb2-s.jpg" {
+		t.Fatalf("second thumbnail listingUrl: got %q, want %q", second.Thumbnail.ListingURL, "https://example.invalid/thumb2-s.jpg")
+	}
+	if second.Duration != 240 {
+		t.Fatalf("second duration: got %d, want 240", second.Duration)
+	}
+	if second.ShortDescription != "desc-2" || second.LatestCommentSummary != "summary-2" {
+		t.Fatalf("unexpected second text fields: short=%q summary=%q", second.ShortDescription, second.LatestCommentSummary)
+	}
+	if second.IsChannelVideo || second.IsPaymentRequired || second.RequireSensitiveMasking {
+		t.Fatalf("unexpected second boolean flags: channel=%t payment=%t masking=%t", second.IsChannelVideo, second.IsPaymentRequired, second.RequireSensitiveMasking)
+	}
+	if second.PlaybackPosition != nil || second.VideoLive != nil {
+		t.Fatalf("expected second playback/videoLive to be nil, got %#v %#v", second.PlaybackPosition, second.VideoLive)
+	}
+	if second.NineD091F87 || second.Acf68865 {
+		t.Fatalf("unexpected second feature flags: 9d091f87=%t acf68865=%t", second.NineD091F87, second.Acf68865)
 	}
 }


### PR DESCRIPTION
## Summary

Tighten the test suite around the review follow-ups from Issue #216 by removing flaky timing assumptions, expanding parser fuzz coverage, stabilizing the live E2E assertion surface, reducing benchmark setup noise, and broadening the JSON fixture contract checks.

## What / Why

The review found a few gaps in the test layer rather than in production behavior. The JSON user ordering test depended on wall-clock sleeps, the parser fuzz target mostly exercised regex behavior instead of parser invariants, the live E2E test was too narrow, the benchmark included setup noise in the measured path, and the `NicoData` contract test left several mapped fields unchecked.

This PR keeps the implementation behavior unchanged while making the test suite more trustworthy. The ordering test now coordinates requests without sleep-based sequencing, the fuzz coverage checks parsed IDs against named captures and malformed submatch shapes, the E2E test validates bounded multi-item results without cross-request live-data comparisons, the benchmark reuses a preallocated buffer to reduce setup noise, and the contract test asserts the remaining fixture-backed fields that matter for schema drift detection.

## Related issues

Closes #216.

## Testing

```bash
gofmt -w cmd/root_test.go cmd/root_fuzz_test.go internal/niconico/e2e_test.go internal/niconico/benchmark_test.go internal/niconico/nico_data_contract_test.go
go test ./cmd -run 'TestRunRootCmdJSONOutputUsersSortedByUserID|FuzzParseInputTargetNoPanic|FuzzSubmatchByNameNoPanic' -count=1
go test ./cmd -run=^$ -fuzz=FuzzParseInputTargetNoPanic -fuzztime=1s
go test ./cmd -run=^$ -fuzz=FuzzSubmatchByNameNoPanic -fuzztime=1s
go test ./internal/niconico -run TestNicoDataContract -count=1
go test ./internal/niconico -run=^$ -bench BenchmarkNiconicoSort -benchmem -count=1
go test -tags=e2e ./internal/niconico -run TestGetVideoListE2E -count=1
go vet ./...
go test ./...
go test -race ./...
go mod tidy
go generate ./...
```

`gofmt -w .` was attempted once, but this repository contains a local `.cache/` tree with read-only Go module/toolchain files, so the command hit permission-denied errors outside the tracked source tree. The changed Go files above were formatted successfully.

## Fix log

- 2026-03-23: Replaced the JSON ordering sleep-based test flow with deterministic coordination and expanded parser fuzz coverage.
- 2026-03-23: Adjusted the live E2E assertions to avoid cross-request comparisons, reduced benchmark setup noise, and broadened `NicoData` fixture assertions.
- 2026-03-23: Re-ran subagent review loops for `cmd` and `internal/niconico` scopes until both reported no findings.
- 2026-03-23: Addressed PR review follow-ups by waiting for user 2 completion in the ordering test and filling fuzzed submatches with sentinel capture values.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [x] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
