### PR TITLE
ci: refresh generated files for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-generated-files.yml
+++ b/.github/workflows/dependabot-generated-files.yml
@@ -1,0 +1,51 @@
+name: Dependabot generated files
+
+permissions:
+  contents: write
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  refresh-generated-files:
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Dependabot branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Refresh generated files
+        run: |
+          go mod tidy
+          go generate ./...
+          bash scripts/gen-third-party-notices.sh
+
+      - name: Commit generated file updates
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if git diff --quiet --exit-code; then
+            echo "No generated file updates needed."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add go.mod go.sum THIRD_PARTY_NOTICES.md
+          git commit -m "chore(deps): refresh generated files"
+          git push origin "HEAD:${HEAD_REF}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,9 @@ The script uses `go-licenses` (pinned in the script) and excludes test-only depe
 Set `GO_LICENSES_SAVE_PATH` when you also want to save license texts to a directory.
 Requires bash and network access.
 
+Same-repository Dependabot module update PRs automatically refresh generated files with the
+`Dependabot generated files` workflow before the required CI drift checks run.
+
 ## Project structure
 
 - `main.go`: bootstrap (version, cancelable context)


### PR DESCRIPTION
## Summary

- Add a Dependabot-only generated-file refresh workflow for same-repository PRs.

- Document the automation in CONTRIBUTING.md.

## What / Why

Dependabot Go module PRs can update go.mod/go.sum while leaving THIRD_PARTY_NOTICES.md stale, which blocks the required CI drift check. The new workflow runs only for dependabot[bot] pull_request_target events from this repository, refreshes generated files, and commits them back to the Dependabot branch before normal CI evaluates drift.

## Related issues

Closes #219

## Testing

```bash
go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/dependabot-generated-files.yml .github/workflows/ci.yml .github/workflows/latest-deps-ci.yml
go mod tidy && go generate ./... && git diff --exit-code -- go.mod go.sum THIRD_PARTY_NOTICES.md
go vet ./...
go test -count=1 ./...
go test -race -count=1 ./...
bash scripts/gen-third-party-notices.sh && git diff --exit-code -- THIRD_PARTY_NOTICES.md
```

## Fix log

2026-04-27: initial workflow and docs update.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
