### PR TITLE
ci: dispatch CI after Dependabot generated updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/dependabot-generated-files.yml
+++ b/.github/workflows/dependabot-generated-files.yml
@@ -1,6 +1,7 @@
 name: Dependabot generated files
 
 permissions:
+  actions: write
   contents: write
 
 on:
@@ -37,6 +38,7 @@ jobs:
 
       - name: Commit generated file updates
         env:
+          GH_TOKEN: ${{ github.token }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if git diff --quiet --exit-code; then
@@ -49,3 +51,4 @@ jobs:
           git add go.mod go.sum THIRD_PARTY_NOTICES.md
           git commit -m "chore(deps): refresh generated files"
           git push origin "HEAD:${HEAD_REF}"
+          gh workflow run ci.yml --ref "${HEAD_REF}"


### PR DESCRIPTION
## Summary

- Allow the required CI workflow to be manually dispatched.

- Trigger that CI run after the Dependabot generated-file workflow pushes generated updates.

## What / Why

The generated-file workflow can update Dependabot branches, but commits made with the GitHub Actions token do not start the normal pull_request CI. Dispatching ci.yml after the push attaches a fresh go-ci run to the updated Dependabot branch so required checks are not left missing.

## Related issues

Closes #219

## Testing

```bash
go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/dependabot-generated-files.yml .github/workflows/ci.yml .github/workflows/latest-deps-ci.yml
go mod tidy && go generate ./... && git diff --exit-code -- go.mod go.sum THIRD_PARTY_NOTICES.md
go vet ./...
go test -count=1 ./...
go test -race -count=1 ./...
```

## Fix log

2026-04-27: dispatch ci.yml after Dependabot generated-file commits.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
