### PR TITLE
fix: sort long video IDs numerically

### DIFF
--- a/internal/niconico/client.go
+++ b/internal/niconico/client.go
@@ -33,23 +33,36 @@ type videoItem struct {
 
 // NiconicoSort sorts video IDs by their numeric part in ascending order.
 func NiconicoSort(slice []string) {
-	const prefixLen = 2
-	str := "%08s"
-
 	sort.Slice(slice, func(i, j int) bool {
-		var s1, s2 string
-		if len(slice[i]) >= prefixLen {
-			s1 = slice[i][prefixLen:]
-		} else {
-			s1 = slice[i]
+		left, leftOK := videoIDNumber(slice[i])
+		right, rightOK := videoIDNumber(slice[j])
+		if leftOK && rightOK {
+			return left < right
 		}
-		if len(slice[j]) >= prefixLen {
-			s2 = slice[j][prefixLen:]
-		} else {
-			s2 = slice[j]
-		}
-		return fmt.Sprintf(str, s1) < fmt.Sprintf(str, s2)
+		return legacyVideoIDSortKey(slice[i]) < legacyVideoIDSortKey(slice[j])
 	})
+}
+
+// videoIDNumber parses the numeric portion of a video ID.
+func videoIDNumber(id string) (int64, bool) {
+	const prefixLen = 2
+	if len(id) >= prefixLen {
+		id = id[prefixLen:]
+	}
+	n, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// legacyVideoIDSortKey returns the historical fallback key for malformed IDs.
+func legacyVideoIDSortKey(id string) string {
+	const prefixLen = 2
+	if len(id) >= prefixLen {
+		id = id[prefixLen:]
+	}
+	return fmt.Sprintf("%08s", id)
 }
 
 // GetVideoList retrieves video IDs for a user.

--- a/internal/niconico/client.go
+++ b/internal/niconico/client.go
@@ -31,38 +31,43 @@ type videoItem struct {
 	RegisteredAt time.Time
 }
 
+// videoIDSortKey stores a total-order key for a video ID.
+type videoIDSortKey struct {
+	length int
+	text   string
+}
+
 // NiconicoSort sorts video IDs by their numeric part in ascending order.
 func NiconicoSort(slice []string) {
 	sort.Slice(slice, func(i, j int) bool {
-		left, leftOK := videoIDNumber(slice[i])
-		right, rightOK := videoIDNumber(slice[j])
-		if leftOK && rightOK {
-			return left < right
+		left := videoIDSortKeyFor(slice[i])
+		right := videoIDSortKeyFor(slice[j])
+		if left.length != right.length {
+			return left.length < right.length
 		}
-		return legacyVideoIDSortKey(slice[i]) < legacyVideoIDSortKey(slice[j])
+		if left.text != right.text {
+			return left.text < right.text
+		}
+		return slice[i] < slice[j]
 	})
 }
 
-// videoIDNumber parses the numeric portion of a video ID.
-func videoIDNumber(id string) (int64, bool) {
-	const prefixLen = 2
-	if len(id) >= prefixLen {
-		id = id[prefixLen:]
+// videoIDSortKeyFor returns a total-order key for a video ID.
+func videoIDSortKeyFor(id string) videoIDSortKey {
+	text := videoIDSortText(id)
+	if n, err := strconv.ParseUint(text, 10, 64); err == nil {
+		text = strconv.FormatUint(n, 10)
 	}
-	n, err := strconv.ParseInt(id, 10, 64)
-	if err != nil {
-		return 0, false
-	}
-	return n, true
+	return videoIDSortKey{length: len(text), text: text}
 }
 
-// legacyVideoIDSortKey returns the historical fallback key for malformed IDs.
-func legacyVideoIDSortKey(id string) string {
+// videoIDSortText returns the comparable text portion of a video ID.
+func videoIDSortText(id string) string {
 	const prefixLen = 2
 	if len(id) >= prefixLen {
-		id = id[prefixLen:]
+		return id[prefixLen:]
 	}
-	return fmt.Sprintf("%08s", id)
+	return id
 }
 
 // GetVideoList retrieves video IDs for a user.

--- a/internal/niconico/client_test.go
+++ b/internal/niconico/client_test.go
@@ -50,6 +50,11 @@ func TestNiconicoSort(t *testing.T) {
 			input:    []string{"sm100000000", "sm99999999", "sm3"},
 			expected: []string{"sm3", "sm99999999", "sm100000000"},
 		},
+		{
+			name:     "malformedWithLongNumericIDs",
+			input:    []string{"sm100000000", "xx200000000a", "sm99999999"},
+			expected: []string{"sm99999999", "sm100000000", "xx200000000a"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/niconico/client_test.go
+++ b/internal/niconico/client_test.go
@@ -45,6 +45,11 @@ func TestNiconicoSort(t *testing.T) {
 			input:    []string{"sm12", "s", "sm3"},
 			expected: []string{"sm3", "s", "sm12"},
 		},
+		{
+			name:     "longNumericIDs",
+			input:    []string{"sm100000000", "sm99999999", "sm3"},
+			expected: []string{"sm3", "sm99999999", "sm100000000"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fix numeric sorting for video IDs whose numeric portion is longer than eight digits.

## What / Why

`NiconicoSort` was documented to sort IDs by numeric value, but it compared fixed-width padded strings. IDs such as `sm100000000` could sort before `sm99999999` even though the numeric value is larger. The sort now parses numeric portions when both IDs are valid and keeps the historical fallback key for malformed IDs.

## Related issues

Closes #225

## Testing

```bash
GOCACHE=/tmp/go-nico-list-go-build go test ./internal/niconico -run TestNiconicoSort -count=1
GOCACHE=/tmp/go-nico-list-go-build go vet ./...
GOCACHE=/tmp/go-nico-list-go-build go test ./...
GOCACHE=/tmp/go-nico-list-go-build GOTOOLCHAIN=go1.26.1 go test -race ./...
GOCACHE=/tmp/go-nico-list-go-build go mod tidy
GOCACHE=/tmp/go-nico-list-go-build go generate ./...
git diff --check
```

## Fix log

- 2026-05-11: Add regression coverage for long numeric IDs and sort valid IDs by parsed numeric value.
- 2026-05-11: Address Codex review by replacing mixed comparison paths with a single total-order sort key and adding malformed/long-ID regression coverage.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [x] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
