### PR TITLE
docs: fix fuzz smoke commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,10 @@ Use these opt-in commands when working on higher-level test coverage:
 go test ./internal/niconico -run TestNicoDataContract -count=1
 
 # Fuzz smoke run (short)
-go test ./... -run=^$ -fuzz=Fuzz -fuzztime=10s
+go test ./cmd -run=^$ -fuzz=FuzzParseInputTargetNoPanic -fuzztime=10s
+go test ./cmd -run=^$ -fuzz=FuzzSubmatchByNameNoPanic -fuzztime=10s
+go test ./internal/niconico -run=^$ -fuzz=FuzzNiconicoSortNoPanic -fuzztime=10s
+go test ./internal/niconico -run=^$ -fuzz=FuzzNicoDataUnmarshalNoPanic -fuzztime=10s
 
 # E2E against real API (requires env var)
 GO_NICO_LIST_E2E_USER_ID=<user-id> go test -tags=e2e ./internal/niconico -run TestGetVideoListE2E -count=1

--- a/README.md
+++ b/README.md
@@ -126,7 +126,10 @@ Opt-in commands:
 
 ```bash
 go test ./internal/niconico -run TestNicoDataContract -count=1
-go test ./... -run=^$ -fuzz=Fuzz -fuzztime=10s
+go test ./cmd -run=^$ -fuzz=FuzzParseInputTargetNoPanic -fuzztime=10s
+go test ./cmd -run=^$ -fuzz=FuzzSubmatchByNameNoPanic -fuzztime=10s
+go test ./internal/niconico -run=^$ -fuzz=FuzzNiconicoSortNoPanic -fuzztime=10s
+go test ./internal/niconico -run=^$ -fuzz=FuzzNicoDataUnmarshalNoPanic -fuzztime=10s
 GO_NICO_LIST_E2E_USER_ID=<user-id> go test -tags=e2e ./internal/niconico -run TestGetVideoListE2E -count=1
 go test ./internal/niconico -run=^$ -bench=BenchmarkNiconicoSort -benchmem -count=1
 ```


### PR DESCRIPTION
## Summary

Fix the documented fuzz smoke commands so contributors can copy and run them successfully.

## What / Why

The previous command used `go test ./... -fuzz=Fuzz`, but Go fuzzing accepts one package at a time and the repository has multiple fuzz targets per package. This PR lists each fuzz target explicitly in `README.md` and `CONTRIBUTING.md`.

## Related issues

Closes #227

## Testing

```bash
gofmt -w $(git ls-files '*.go')
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go vet ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache GOLANGCI_LINT_CACHE=/tmp/go-nico-list-golangci-lint-cache golangci-lint run ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test -count=1 ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test -race -count=1 ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go mod tidy
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go generate ./...
git diff --exit-code
git diff --cached --exit-code

GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test ./cmd -run=^$ -fuzz=FuzzParseInputTargetNoPanic -fuzztime=10s
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test ./cmd -run=^$ -fuzz=FuzzSubmatchByNameNoPanic -fuzztime=10s
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test ./internal/niconico -run=^$ -fuzz=FuzzNiconicoSortNoPanic -fuzztime=10s
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test ./internal/niconico -run=^$ -fuzz=FuzzNicoDataUnmarshalNoPanic -fuzztime=10s
```

## Fix log

- 2026-05-17: replaced the invalid aggregate fuzz smoke command with explicit per-target commands and verified each target.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
