### PR TITLE
fix: preserve target type in JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Notes:
 - `--best-effort` forces exit code 0 even when fetch errors occur (errors are still logged).
 - `--dedupe` removes duplicate video IDs before sorting/output.
 - `--json` emits a single JSON object to stdout. `--tab`/`--url` do not affect JSON `items`, and the summary still prints to stderr.
-- In JSON output, `users` are sorted by numeric `user_id` in ascending order.
+- In JSON output, `targets` include `type` (`user` or `mylist`) and `id`, sorted by type and numeric id in ascending order.
 
 ## Design
 This project separates the CLI layer from the domain logic so each part is easier to test and maintain.

--- a/cmd/root_json.go
+++ b/cmd/root_json.go
@@ -15,21 +15,22 @@ type jsonInputs struct {
 	Invalid int64 `json:"invalid"`
 }
 
-// userResult captures per-user results for JSON output.
-type userResult struct {
-	UserID string   `json:"user_id"`
-	Items  []string `json:"items"`
-	Error  string   `json:"error"`
+// targetResult captures per-input-target results for JSON output.
+type targetResult struct {
+	Type  string   `json:"type"`
+	ID    string   `json:"id"`
+	Items []string `json:"items"`
+	Error string   `json:"error"`
 }
 
 // jsonOutputPayload defines the JSON output schema.
 type jsonOutputPayload struct {
-	Inputs      jsonInputs   `json:"inputs"`
-	Invalid     []string     `json:"invalid"`
-	Users       []userResult `json:"users"`
-	Errors      []string     `json:"errors"`
-	OutputCount int          `json:"output_count"`
-	Items       []string     `json:"items"`
+	Inputs      jsonInputs     `json:"inputs"`
+	Invalid     []string       `json:"invalid"`
+	Targets     []targetResult `json:"targets"`
+	Errors      []string       `json:"errors"`
+	OutputCount int            `json:"output_count"`
+	Items       []string       `json:"items"`
 }
 
 // buildJSONOutput assembles the JSON payload from run results.
@@ -38,7 +39,7 @@ func buildJSONOutput(
 	validInputs int64,
 	invalidInputs int64,
 	invalidInputsList []string,
-	userResults []userResult,
+	targetResults []targetResult,
 	errorsList []string,
 	outputCount int,
 	outputIDs []string,
@@ -47,12 +48,13 @@ func buildJSONOutput(
 	for _, id := range outputIDs {
 		items = append(items, normalizeOutputID(id))
 	}
-	users := make([]userResult, 0, len(userResults))
-	for _, user := range userResults {
-		users = append(users, userResult{
-			UserID: user.UserID,
-			Items:  normalizeOutputList(user.Items),
-			Error:  user.Error,
+	targets := make([]targetResult, 0, len(targetResults))
+	for _, target := range targetResults {
+		targets = append(targets, targetResult{
+			Type:  target.Type,
+			ID:    target.ID,
+			Items: normalizeOutputList(target.Items),
+			Error: target.Error,
 		})
 	}
 	return jsonOutputPayload{
@@ -62,18 +64,21 @@ func buildJSONOutput(
 			Invalid: invalidInputs,
 		},
 		Invalid:     append([]string{}, invalidInputsList...),
-		Users:       users,
+		Targets:     targets,
 		Errors:      append([]string{}, errorsList...),
 		OutputCount: outputCount,
 		Items:       items,
 	}
 }
 
-// sortUserResultsByUserID sorts user results by numeric user_id in ascending order.
-func sortUserResultsByUserID(results []userResult) {
+// sortTargetResults sorts target results by type and numeric id in ascending order.
+func sortTargetResults(results []targetResult) {
 	sort.Slice(results, func(i, j int) bool {
-		leftID, leftErr := strconv.Atoi(results[i].UserID)
-		rightID, rightErr := strconv.Atoi(results[j].UserID)
+		if results[i].Type != results[j].Type {
+			return results[i].Type < results[j].Type
+		}
+		leftID, leftErr := strconv.Atoi(results[i].ID)
+		rightID, rightErr := strconv.Atoi(results[j].ID)
 		if leftErr == nil && rightErr == nil && leftID != rightID {
 			return leftID < rightID
 		}
@@ -83,8 +88,8 @@ func sortUserResultsByUserID(results []userResult) {
 		if leftErr != nil && rightErr == nil {
 			return false
 		}
-		if results[i].UserID != results[j].UserID {
-			return results[i].UserID < results[j].UserID
+		if results[i].ID != results[j].ID {
+			return results[i].ID < results[j].ID
 		}
 		return results[i].Error < results[j].Error
 	})

--- a/cmd/root_json.go
+++ b/cmd/root_json.go
@@ -77,8 +77,8 @@ func sortTargetResults(results []targetResult) {
 		if results[i].Type != results[j].Type {
 			return results[i].Type < results[j].Type
 		}
-		leftID, leftErr := strconv.Atoi(results[i].ID)
-		rightID, rightErr := strconv.Atoi(results[j].ID)
+		leftID, leftErr := strconv.ParseUint(results[i].ID, 10, 64)
+		rightID, rightErr := strconv.ParseUint(results[j].ID, 10, 64)
 		if leftErr == nil && rightErr == nil && leftID != rightID {
 			return leftID < rightID
 		}

--- a/cmd/root_run.go
+++ b/cmd/root_run.go
@@ -149,7 +149,7 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 	var fetchOKCount int64
 	var fetchErrCount int64
 	invalidInputsList := make([]string, 0)
-	userResults := make([]userResult, 0)
+	targetResults := make([]targetResult, 0)
 	errorsList := make([]string, 0)
 
 	bar := newProgressBar(cmd, stream.totalKnown, stream.total)
@@ -239,10 +239,11 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 				atomic.AddInt64(&fetchErrCount, 1)
 				mu.Lock()
 				errorsList = append(errorsList, err.Error())
-				userResults = append(userResults, userResult{
-					UserID: target.ID,
-					Items:  newList,
-					Error:  err.Error(),
+				targetResults = append(targetResults, targetResult{
+					Type:  target.Type,
+					ID:    target.ID,
+					Items: newList,
+					Error: err.Error(),
 				})
 				idList = append(idList, newList...)
 				mu.Unlock()
@@ -251,10 +252,11 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 			}
 			atomic.AddInt64(&fetchOKCount, 1)
 			mu.Lock()
-			userResults = append(userResults, userResult{
-				UserID: target.ID,
-				Items:  newList,
-				Error:  "",
+			targetResults = append(targetResults, targetResult{
+				Type:  target.Type,
+				ID:    target.ID,
+				Items: newList,
+				Error: "",
 			})
 			idList = append(idList, newList...)
 			mu.Unlock()
@@ -263,7 +265,7 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 	wg.Wait()
 	close(errCh)
 	fetchErrRet := <-fetchErrCh
-	sortUserResultsByUserID(userResults)
+	sortTargetResults(targetResults)
 	if inputErr == nil {
 		for err := range inputErrCh {
 			if err != nil {
@@ -298,7 +300,7 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 			validInputs,
 			invalidInputs,
 			invalidInputsList,
-			userResults,
+			targetResults,
 			errorsList,
 			outputCount,
 			outputIDs,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -681,18 +681,21 @@ func TestRunRootCmdJSONOutput(t *testing.T) {
 	if len(payload.Invalid) != 1 || payload.Invalid[0] != "invalid" {
 		t.Errorf("unexpected invalid list: %+v", payload.Invalid)
 	}
-	if len(payload.Users) != 1 {
-		t.Fatalf("unexpected users length: %d", len(payload.Users))
+	if len(payload.Targets) != 1 {
+		t.Fatalf("unexpected targets length: %d", len(payload.Targets))
 	}
-	user := payload.Users[0]
-	if user.UserID != "1" {
-		t.Errorf("unexpected user_id: %s", user.UserID)
+	target := payload.Targets[0]
+	if target.Type != targetTypeUser {
+		t.Errorf("unexpected target type: %s", target.Type)
 	}
-	if user.Error != "" {
-		t.Errorf("expected empty user error, got %q", user.Error)
+	if target.ID != "1" {
+		t.Errorf("unexpected target id: %s", target.ID)
 	}
-	if got := strings.Join(user.Items, ","); got != "sm2,sm1,sm1" {
-		t.Errorf("unexpected user items: %v", user.Items)
+	if target.Error != "" {
+		t.Errorf("expected empty target error, got %q", target.Error)
+	}
+	if got := strings.Join(target.Items, ","); got != "sm2,sm1,sm1" {
+		t.Errorf("unexpected target items: %v", target.Items)
 	}
 	if payload.OutputCount != 2 {
 		t.Errorf("unexpected output_count: %d", payload.OutputCount)
@@ -775,25 +778,31 @@ func TestRunRootCmdJSONOutputWithFetchError(t *testing.T) {
 	if payload.Inputs.Total != 2 || payload.Inputs.Valid != 2 || payload.Inputs.Invalid != 0 {
 		t.Errorf("unexpected inputs: %+v", payload.Inputs)
 	}
-	if len(payload.Users) != 2 {
-		t.Fatalf("unexpected users length: %d", len(payload.Users))
+	if len(payload.Targets) != 2 {
+		t.Fatalf("unexpected targets length: %d", len(payload.Targets))
 	}
-	user1 := payload.Users[0]
-	if user1.UserID != "1" {
-		t.Errorf("unexpected user_id: %s", user1.UserID)
+	target1 := payload.Targets[0]
+	if target1.Type != targetTypeUser {
+		t.Errorf("unexpected target type: %s", target1.Type)
 	}
-	if got := strings.Join(user1.Items, ","); got != "sm1" {
-		t.Errorf("unexpected user1 items: %v", user1.Items)
+	if target1.ID != "1" {
+		t.Errorf("unexpected target id: %s", target1.ID)
 	}
-	user2 := payload.Users[1]
-	if user2.UserID != "2" {
-		t.Errorf("unexpected user_id: %s", user2.UserID)
+	if got := strings.Join(target1.Items, ","); got != "sm1" {
+		t.Errorf("unexpected target1 items: %v", target1.Items)
 	}
-	if user2.Error == "" {
-		t.Errorf("expected user2 error, got empty")
+	target2 := payload.Targets[1]
+	if target2.Type != targetTypeUser {
+		t.Errorf("unexpected target type: %s", target2.Type)
 	}
-	if len(user2.Items) != 0 {
-		t.Errorf("unexpected user2 items: %v", user2.Items)
+	if target2.ID != "2" {
+		t.Errorf("unexpected target id: %s", target2.ID)
+	}
+	if target2.Error == "" {
+		t.Errorf("expected target2 error, got empty")
+	}
+	if len(target2.Items) != 0 {
+		t.Errorf("unexpected target2 items: %v", target2.Items)
 	}
 	if payload.OutputCount != 1 {
 		t.Errorf("unexpected output_count: %d", payload.OutputCount)
@@ -809,7 +818,7 @@ func TestRunRootCmdJSONOutputWithFetchError(t *testing.T) {
 	}
 }
 
-func TestRunRootCmdJSONOutputUsersSortedByUserID(t *testing.T) {
+func TestRunRootCmdJSONOutputTargetsSortedByTypeAndID(t *testing.T) {
 	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	dateafter = "10000101"
 	datebefore = "99991231"
@@ -883,11 +892,118 @@ func TestRunRootCmdJSONOutputUsersSortedByUserID(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
 		t.Fatalf("failed to parse JSON output: %v", err)
 	}
-	if len(payload.Users) != 2 {
-		t.Fatalf("unexpected users length: %d", len(payload.Users))
+	if len(payload.Targets) != 2 {
+		t.Fatalf("unexpected targets length: %d", len(payload.Targets))
 	}
-	if payload.Users[0].UserID != "1" || payload.Users[1].UserID != "2" {
-		t.Fatalf("expected users ordered by user_id, got %+v", payload.Users)
+	if payload.Targets[0].Type != targetTypeUser || payload.Targets[0].ID != "1" ||
+		payload.Targets[1].Type != targetTypeUser || payload.Targets[1].ID != "2" {
+		t.Fatalf("expected targets ordered by type and id, got %+v", payload.Targets)
+	}
+}
+
+func TestRunRootCmdJSONOutputPreservesMylistTargetType(t *testing.T) {
+	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	dateafter = "10000101"
+	datebefore = "99991231"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/mylists/847130") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") != "1" {
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"items":[]}}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"items":[{"video":{"id":"sm42","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	oldBaseURL := baseURL
+	baseURL = server.URL
+	t.Cleanup(func() { baseURL = oldBaseURL })
+
+	oldRetries := retries
+	retries = 1
+	t.Cleanup(func() { retries = oldRetries })
+
+	oldConcurrency := concurrency
+	concurrency = 1
+	t.Cleanup(func() { concurrency = oldConcurrency })
+
+	oldTimeout := httpClientTimeout
+	httpClientTimeout = time.Second
+	t.Cleanup(func() { httpClientTimeout = oldTimeout })
+
+	origJSON := jsonOutput
+	origNoProgress := noProgress
+	origForceProgress := forceProgress
+	jsonOutput = true
+	noProgress = true
+	forceProgress = false
+	t.Cleanup(func() {
+		jsonOutput = origJSON
+		noProgress = origNoProgress
+		forceProgress = origForceProgress
+	})
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetContext(context.Background())
+
+	if err := runRootCmd(cmd, []string{"nicovideo.jp/mylist/847130"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload struct {
+		Targets []struct {
+			Type  string   `json:"type"`
+			ID    string   `json:"id"`
+			Items []string `json:"items"`
+			Error string   `json:"error"`
+		} `json:"targets"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to parse JSON output: %v", err)
+	}
+	if len(payload.Targets) != 1 {
+		t.Fatalf("unexpected targets length: %d; output=%s", len(payload.Targets), out.String())
+	}
+	target := payload.Targets[0]
+	if target.Type != targetTypeMylist {
+		t.Errorf("unexpected target type: %s", target.Type)
+	}
+	if target.ID != "847130" {
+		t.Errorf("unexpected target id: %s", target.ID)
+	}
+	if got := strings.Join(target.Items, ","); got != "sm42" {
+		t.Errorf("unexpected target items: %v", target.Items)
+	}
+	if target.Error != "" {
+		t.Errorf("expected empty target error, got %q", target.Error)
+	}
+}
+
+func TestSortTargetResultsSortsByTypeAndNumericID(t *testing.T) {
+	results := []targetResult{
+		{Type: targetTypeUser, ID: "10"},
+		{Type: targetTypeMylist, ID: "2"},
+		{Type: targetTypeUser, ID: "1"},
+		{Type: targetTypeMylist, ID: "11"},
+	}
+
+	sortTargetResults(results)
+
+	got := make([]string, 0, len(results))
+	for _, result := range results {
+		got = append(got, result.Type+":"+result.ID)
+	}
+	if strings.Join(got, ",") != "mylist:2,mylist:11,user:1,user:10" {
+		t.Fatalf("unexpected target order: %v", got)
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -994,6 +994,8 @@ func TestSortTargetResultsSortsByTypeAndNumericID(t *testing.T) {
 		{Type: targetTypeMylist, ID: "2"},
 		{Type: targetTypeUser, ID: "1"},
 		{Type: targetTypeMylist, ID: "11"},
+		{Type: targetTypeMylist, ID: "10000000000"},
+		{Type: targetTypeMylist, ID: "9999999999"},
 	}
 
 	sortTargetResults(results)
@@ -1002,7 +1004,7 @@ func TestSortTargetResultsSortsByTypeAndNumericID(t *testing.T) {
 	for _, result := range results {
 		got = append(got, result.Type+":"+result.ID)
 	}
-	if strings.Join(got, ",") != "mylist:2,mylist:11,user:1,user:10" {
+	if strings.Join(got, ",") != "mylist:2,mylist:11,mylist:9999999999,mylist:10000000000,user:1,user:10" {
 		t.Fatalf("unexpected target order: %v", got)
 	}
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -94,7 +94,7 @@ main.go
     - Schema:
       - `inputs`: `{ "total": n, "valid": n, "invalid": n }`
       - `invalid`: list of invalid input strings
-      - `users`: list of `{ "user_id": "<id>", "items": ["sm1"], "error": "" }`, sorted by numeric `user_id` ascending
+      - `targets`: list of `{ "type": "user|mylist", "id": "<id>", "items": ["sm1"], "error": "" }`, sorted by `type` then numeric `id` ascending
       - `errors`: list of fetch error messages (order is nondeterministic)
       - `output_count`: count of `items` after dedupe (if enabled)
       - `items`: flattened list of IDs (raw `sm*` IDs; `--url`/`--tab` do not affect JSON)


### PR DESCRIPTION
## Summary

Preserve the input target type in `--json` per-target output.

## What / Why

Replaced the JSON `users` list with `targets`, where each entry includes `type`, `id`, `items`, and `error`. This keeps mylist inputs distinguishable from user inputs and aligns the JSON schema with supported input target types.

## Related issues

Closes #228

## Testing

```bash
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test ./cmd -run TestRunRootCmdJSONOutputPreservesMylistTargetType -count=1
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test ./cmd -run 'Test(RunRootCmdJSONOutput|RunRootCmdJSONOutputWithFetchError|RunRootCmdJSONOutputTargetsSortedByTypeAndID|RunRootCmdJSONOutputPreservesMylistTargetType|SortTargetResultsSortsByTypeAndNumericID)$' -count=1
GOARCH=386 GOPATH=/tmp/go-nico-list-gopath-386 GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache-386 go test ./cmd -run TestSortTargetResultsSortsByTypeAndNumericID -count=1
gofmt -w $(git ls-files '*.go')
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go vet ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache GOLANGCI_LINT_CACHE=/tmp/go-nico-list-golangci-lint-cache golangci-lint run ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test -count=1 ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test -race -count=1 ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go mod tidy
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go generate ./...
git diff --check
git diff --exit-code -- go.mod go.sum THIRD_PARTY_NOTICES.md
git diff --exit-code
git diff --cached --exit-code
```

## Fix log

- 2026-05-17: replaced `users[].user_id` JSON output with `targets[].{type,id}`, updated docs, and added mylist target coverage.
- 2026-05-17: addressed review by parsing target IDs as 64-bit unsigned integers and adding 32-bit GOARCH coverage for 12-digit mylist IDs.

## Breaking change

- [x] Yes
- [ ] No

`--json` output now uses `targets` instead of `users`; per-target IDs are emitted as `id` with an explicit `type`.

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
