### PR TITLE
fix: enable errcheck lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ version: "2"
 linters:
   default: none
   enable:
+    - errcheck
     - ineffassign
     - staticcheck
     - unused

--- a/cmd/root_io.go
+++ b/cmd/root_io.go
@@ -115,8 +115,11 @@ func streamLinesFromFile(path string, out chan<- string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer file.Close()
-	return streamLines(file, out)
+	count, err := streamLines(file, out)
+	if closeErr := file.Close(); err == nil && closeErr != nil {
+		err = closeErr
+	}
+	return count, err
 }
 
 // streamLines streams non-empty trimmed lines from a reader into out.

--- a/cmd/root_run.go
+++ b/cmd/root_run.go
@@ -294,6 +294,7 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 		niconico.NiconicoSort(outputIDs)
 	}
 	out := outWriterFor(cmd)
+	var outputErr error
 	if jsonOutput {
 		jsonPayload := buildJSONOutput(
 			totalInputs,
@@ -307,12 +308,12 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 		)
 		enc := json.NewEncoder(out)
 		if err := enc.Encode(jsonPayload); err != nil {
-			return err
+			outputErr = err
 		}
 	} else if outputCount > 0 {
 		formattedIDs := formatOutputIDs(outputIDs, tab, url)
 		if _, err := fmt.Fprintln(out, strings.Join(formattedIDs, "\n")); err != nil {
-			return err
+			outputErr = err
 		}
 	}
 	if shouldShowProgress(errWriter) {
@@ -331,6 +332,9 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 		outputCount,
 	); err != nil {
 		return err
+	}
+	if outputErr != nil {
+		return outputErr
 	}
 	if inputErr != nil {
 		return inputErr

--- a/cmd/root_run.go
+++ b/cmd/root_run.go
@@ -156,7 +156,7 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 	var progressMu sync.Mutex
 	addProgress := func() {
 		progressMu.Lock()
-		bar.Add(1)
+		_ = bar.Add(1)
 		progressMu.Unlock()
 	}
 
@@ -311,12 +311,16 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 		}
 	} else if outputCount > 0 {
 		formattedIDs := formatOutputIDs(outputIDs, tab, url)
-		fmt.Fprintln(out, strings.Join(formattedIDs, "\n"))
+		if _, err := fmt.Fprintln(out, strings.Join(formattedIDs, "\n")); err != nil {
+			return err
+		}
 	}
 	if shouldShowProgress(errWriter) {
-		fmt.Fprintln(errWriter)
+		if _, err := fmt.Fprintln(errWriter); err != nil {
+			return err
+		}
 	}
-	fmt.Fprintf(
+	if _, err := fmt.Fprintf(
 		errWriter,
 		"summary inputs=%d valid=%d invalid=%d fetch_ok=%d fetch_err=%d output_count=%d\n",
 		atomic.LoadInt64(&totalInputs),
@@ -325,7 +329,9 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 		atomic.LoadInt64(&fetchOKCount),
 		atomic.LoadInt64(&fetchErrCount),
 		outputCount,
-	)
+	); err != nil {
+		return err
+	}
 	if inputErr != nil {
 		return inputErr
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1248,6 +1248,62 @@ func TestRunRootCmdReturnsLineOutputWriteError(t *testing.T) {
 	if !errors.Is(err, writeErr) {
 		t.Fatalf("expected stdout error, got %v", err)
 	}
+	wantSummary := "summary inputs=1 valid=1 invalid=0 fetch_ok=1 fetch_err=0 output_count=1"
+	if got := errOut.String(); !strings.Contains(got, wantSummary) {
+		t.Fatalf("expected summary %q, got %q", wantSummary, got)
+	}
+}
+
+func TestRunRootCmdReturnsJSONOutputWriteError(t *testing.T) {
+	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	dateafter = "10000101"
+	datebefore = "99991231"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") != "1" {
+			_, _ = io.WriteString(w, `{"data":{"items":[]}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":{"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	oldBaseURL := baseURL
+	baseURL = server.URL
+	t.Cleanup(func() { baseURL = oldBaseURL })
+
+	oldRetries := retries
+	retries = 1
+	t.Cleanup(func() { retries = oldRetries })
+
+	oldConcurrency := concurrency
+	concurrency = 1
+	t.Cleanup(func() { concurrency = oldConcurrency })
+
+	oldTimeout := httpClientTimeout
+	httpClientTimeout = time.Second
+	t.Cleanup(func() { httpClientTimeout = oldTimeout })
+
+	origJSON := jsonOutput
+	jsonOutput = true
+	t.Cleanup(func() { jsonOutput = origJSON })
+
+	writeErr := errors.New("stdout failed")
+	var errOut bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(errorWriter{err: writeErr})
+	cmd.SetErr(&errOut)
+	cmd.SetContext(context.Background())
+
+	err := runRootCmd(cmd, []string{"nicovideo.jp/user/1"})
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("expected stdout error, got %v", err)
+	}
+	wantSummary := "summary inputs=1 valid=1 invalid=0 fetch_ok=1 fetch_err=0 output_count=1"
+	if got := errOut.String(); !strings.Contains(got, wantSummary) {
+		t.Fatalf("expected summary %q, got %q", wantSummary, got)
+	}
 }
 
 func TestRunRootCmdReturnsSummaryWriteError(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1167,6 +1167,129 @@ func (r blockingErrorReader) Read(p []byte) (int, error) {
 	return 0, r.err
 }
 
+type closeErrorReader struct {
+	*strings.Reader
+	err error
+}
+
+func (r closeErrorReader) Close() error {
+	return r.err
+}
+
+type errorWriter struct {
+	err error
+}
+
+func (w errorWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+func TestStreamLinesFromFileReturnsCloseError(t *testing.T) {
+	closeErr := errors.New("close failed")
+	oldOpenInputFile := openInputFile
+	openInputFile = func(string) (io.ReadCloser, error) {
+		return closeErrorReader{
+			Reader: strings.NewReader("nicovideo.jp/user/1\n"),
+			err:    closeErr,
+		}, nil
+	}
+	t.Cleanup(func() { openInputFile = oldOpenInputFile })
+
+	out := make(chan string, 1)
+	count, err := streamLinesFromFile("dummy", out)
+
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("expected close error, got %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("unexpected count: %d", count)
+	}
+}
+
+func TestRunRootCmdReturnsLineOutputWriteError(t *testing.T) {
+	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	dateafter = "10000101"
+	datebefore = "99991231"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") != "1" {
+			_, _ = io.WriteString(w, `{"data":{"items":[]}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"data":{"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	oldBaseURL := baseURL
+	baseURL = server.URL
+	t.Cleanup(func() { baseURL = oldBaseURL })
+
+	oldRetries := retries
+	retries = 1
+	t.Cleanup(func() { retries = oldRetries })
+
+	oldConcurrency := concurrency
+	concurrency = 1
+	t.Cleanup(func() { concurrency = oldConcurrency })
+
+	oldTimeout := httpClientTimeout
+	httpClientTimeout = time.Second
+	t.Cleanup(func() { httpClientTimeout = oldTimeout })
+
+	writeErr := errors.New("stdout failed")
+	var errOut bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(errorWriter{err: writeErr})
+	cmd.SetErr(&errOut)
+	cmd.SetContext(context.Background())
+
+	err := runRootCmd(cmd, []string{"nicovideo.jp/user/1"})
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("expected stdout error, got %v", err)
+	}
+}
+
+func TestRunRootCmdReturnsSummaryWriteError(t *testing.T) {
+	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	dateafter = "10000101"
+	datebefore = "99991231"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"items":[]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	oldBaseURL := baseURL
+	baseURL = server.URL
+	t.Cleanup(func() { baseURL = oldBaseURL })
+
+	oldRetries := retries
+	retries = 1
+	t.Cleanup(func() { retries = oldRetries })
+
+	oldConcurrency := concurrency
+	concurrency = 1
+	t.Cleanup(func() { concurrency = oldConcurrency })
+
+	oldTimeout := httpClientTimeout
+	httpClientTimeout = time.Second
+	t.Cleanup(func() { httpClientTimeout = oldTimeout })
+
+	writeErr := errors.New("stderr failed")
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	cmd.SetErr(errorWriter{err: writeErr})
+	cmd.SetContext(context.Background())
+
+	err := runRootCmd(cmd, []string{"nicovideo.jp/user/1"})
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("expected stderr error, got %v", err)
+	}
+}
+
 func TestRunRootCmdInputReadErrorCancelsFetches(t *testing.T) {
 	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	dateafter = "10000101"

--- a/internal/niconico/client.go
+++ b/internal/niconico/client.go
@@ -241,7 +241,7 @@ func evaluateResponse(res *http.Response) (*http.Response, time.Duration, error)
 		return res, 0, nil
 	}
 	retryAfter := retryAfterDelay(res)
-	res.Body.Close()
+	_ = res.Body.Close()
 	return nil, retryAfter, fmt.Errorf("unexpected status: %d", res.StatusCode)
 }
 
@@ -274,12 +274,12 @@ func retriesRequest(ctx context.Context, url string, httpClientTimeout time.Dura
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				if res != nil {
-					res.Body.Close()
+					_ = res.Body.Close()
 				}
 				return nil, err
 			}
 			if res != nil {
-				res.Body.Close()
+				_ = res.Body.Close()
 			}
 			lastErr = err
 		} else {

--- a/internal/niconico/client_test.go
+++ b/internal/niconico/client_test.go
@@ -133,7 +133,7 @@ func TestRetriesRequest(t *testing.T) {
 	if len(headerErrs) > 0 {
 		t.Fatalf("header assertions failed: %v", headerErrs)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 }
 
 func TestRetriesRequestExhaustedReturnsError(t *testing.T) {


### PR DESCRIPTION
## Summary

Enable `errcheck` in the golangci-lint gate.

## What / Why

Handled meaningful ignored errors for input file close and CLI output writes, marked best-effort progress/HTTP cleanup closes as intentional ignores, and added focused tests for the error paths. This lets CI catch future unchecked errors without leaving the known rollout findings unresolved.

## Related issues

Closes #230

## Testing

```bash
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache GOLANGCI_LINT_CACHE=/tmp/go-nico-list-golangci-lint-cache golangci-lint run --default=none -E errcheck ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test ./cmd -run 'Test(StreamLinesFromFileReturnsCloseError|RunRootCmdReturnsLineOutputWriteError|RunRootCmdReturnsSummaryWriteError)$' -count=1
gofmt -w cmd/root_io.go cmd/root_run.go cmd/root_test.go internal/niconico/client.go internal/niconico/client_test.go
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test ./cmd -run TestRunRootCmdReturnsLineOutputWriteError -count=1
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test ./cmd -run 'TestRunRootCmdReturns(LineOutput|Summary)WriteError$' -count=1
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test ./cmd -run 'TestRunRootCmdReturns(LineOutput|JSONOutput|Summary)WriteError$' -count=1
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go vet ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache GOLANGCI_LINT_CACHE=/tmp/go-nico-list-golangci-lint-cache golangci-lint run ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test -count=1 ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test -race -count=1 ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go mod tidy
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go generate ./...
git diff --check
git diff --exit-code -- go.mod go.sum THIRD_PARTY_NOTICES.md
git diff --exit-code
git diff --cached --exit-code
```

Subagent review: no important findings; JSON output write-error test gap addressed.

## Fix log

- 2026-05-18: handled errcheck findings, enabled `errcheck`, added focused regression tests, and verified the full local gate.
- 2026-05-18: addressed review feedback by preserving summary emission before returning stdout/json output write errors, then added line and JSON output regression coverage.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [ ] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
