### PR TITLE
fix: enable copyloopvar lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
   default: none
   enable:
     - errcheck
+    - copyloopvar
     - ineffassign
     - staticcheck
     - unused

--- a/internal/niconico/client_test.go
+++ b/internal/niconico/client_test.go
@@ -58,7 +58,6 @@ func TestNiconicoSort(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			slice := append([]string(nil), tt.input...)
 			NiconicoSort(slice)
@@ -286,7 +285,6 @@ func TestNewRateLimiterInterval(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			limiter := NewRateLimiter(tt.rateLimit, tt.minInterval)
 			if tt.wantNil {
@@ -463,7 +461,6 @@ func TestRetryAfterDelay(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.res != nil && tt.header != "" {
 				tt.res.Header.Set("Retry-After", tt.header)


### PR DESCRIPTION
## Summary

Enable `copyloopvar` in the golangci-lint gate.

## What / Why

Removed obsolete Go 1.21-era loop variable copies from table-driven tests and enabled `copyloopvar` so the lint gate keeps those compatibility patterns from returning.

## Related issues

Closes #232

## Testing

```bash
gofmt -w internal/niconico/client_test.go
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache GOLANGCI_LINT_CACHE=/tmp/go-nico-list-golangci-lint-cache golangci-lint run --default=none -E copyloopvar ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go vet ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test -count=1 ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache GOLANGCI_LINT_CACHE=/tmp/go-nico-list-golangci-lint-cache golangci-lint run ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test -race -count=1 ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go mod tidy
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go generate ./...
git diff --check
git diff --exit-code -- go.mod go.sum THIRD_PARTY_NOTICES.md
```

## Fix log

- 2026-05-20: removed stale loop variable copies, enabled `copyloopvar`, and verified the local gate.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [ ] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
