### PR TITLE
fix: enable bodyclose lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ version: "2"
 linters:
   default: none
   enable:
+    - bodyclose
     - errcheck
     - copyloopvar
     - ineffassign

--- a/internal/niconico/client_test.go
+++ b/internal/niconico/client_test.go
@@ -149,6 +149,7 @@ func TestRetriesRequestExhaustedReturnsError(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 	if res != nil {
+		_ = res.Body.Close()
 		t.Errorf("expected nil response, got %v", res)
 	}
 	if count != retries {
@@ -173,7 +174,10 @@ func TestRetriesRequestBackoffCanceled(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := retriesRequest(ctx, server.URL, time.Second, retries, nil)
+		res, err := retriesRequest(ctx, server.URL, time.Second, retries, nil)
+		if res != nil {
+			_ = res.Body.Close()
+		}
 		errCh <- err
 	}()
 
@@ -206,6 +210,7 @@ func TestRetriesRequestContextCanceled(t *testing.T) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 	if res != nil {
+		_ = res.Body.Close()
 		t.Errorf("expected nil response, got %v", res)
 	}
 }
@@ -227,6 +232,7 @@ func TestRetriesRequestTimeout(t *testing.T) {
 		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}
 	if res != nil {
+		_ = res.Body.Close()
 		t.Errorf("expected nil response, got %v", res)
 	}
 


### PR DESCRIPTION
## Summary

Enable `bodyclose` in the golangci-lint gate.

## What / Why

Closed response bodies defensively in retry error-path tests when helper calls unexpectedly return a response, then enabled `bodyclose` so tests keep explicit response-body ownership.

## Related issues

Closes #231

## Testing

```bash
gofmt -w internal/niconico/client_test.go
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache GOLANGCI_LINT_CACHE=/tmp/go-nico-list-golangci-lint-cache golangci-lint run --default=none -E bodyclose ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go vet ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test -count=1 ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache GOLANGCI_LINT_CACHE=/tmp/go-nico-list-golangci-lint-cache golangci-lint run ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go test -race -count=1 ./...
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go mod tidy
GOPATH=/tmp/go-nico-list-gopath GOMODCACHE=/tmp/go-nico-list-gomodcache GOCACHE=/tmp/go-nico-list-gocache go generate ./...
git diff --check
git diff --exit-code -- go.mod go.sum THIRD_PARTY_NOTICES.md
git diff --exit-code
git diff --cached --exit-code
```

## Fix log

- 2026-05-20: closed retry test response bodies on defensive non-nil paths, enabled `bodyclose`, and verified the local gate.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [ ] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
