### PR TITLE
ci: enable additional golangci-lint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,14 @@ linters:
     - bodyclose
     - errcheck
     - copyloopvar
+    - durationcheck
+    - errorlint
+    - loggercheck
+    - makezero
+    - misspell
+    - nilerr
+    - nilnil
+    - noctx
     - ineffassign
     - staticcheck
     - unused


### PR DESCRIPTION
## Summary

Enable additional golangci-lint checks that already pass without source changes.

## What / Why

Added the following low-risk linters to `.golangci.yml`: `durationcheck`, `errorlint`, `loggercheck`, `makezero`, `misspell`, `nilerr`, `nilnil`, and `noctx`.

These cover the linter-tracking issues that reported no findings in the current codebase. `sloglint` is intentionally left out because its tracking issue requires code changes.

## Related issues

Closes #242
Closes #243
Closes #244
Closes #245
Closes #246
Closes #247
Closes #248
Closes #250

## Testing

```bash
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build GOLANGCI_LINT_CACHE=/tmp/go-nico-list-golangci-cache golangci-lint run --enable-only=errorlint,nilerr,nilnil,durationcheck,makezero,noctx,loggercheck,misspell ./...
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build GOLANGCI_LINT_CACHE=/tmp/go-nico-list-golangci-cache golangci-lint run ./...
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build go vet ./...
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build go test ./...
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build go test -race ./...
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build go generate ./...
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build go mod tidy
git diff --exit-code
```

## Fix log

- 2026-05-21: initial implementation, enabled lint-only checks that pass without source changes.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [ ] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
