### PR TITLE
ci: enable sloglint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - nilerr
     - nilnil
     - noctx
+    - sloglint
     - ineffassign
     - staticcheck
     - unused

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestRetriesValidation(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	retries = 0
 	t.Cleanup(func() { retries = defaultRetries })
 
@@ -34,7 +34,7 @@ func TestRetriesValidation(t *testing.T) {
 }
 
 func TestRateLimitValidation(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 	oldConcurrency := concurrency
@@ -55,7 +55,7 @@ func TestRateLimitValidation(t *testing.T) {
 }
 
 func TestTimeoutValidation(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 	oldTimeout := httpClientTimeout
@@ -70,7 +70,7 @@ func TestTimeoutValidation(t *testing.T) {
 }
 
 func TestDateRangeOrderValidation(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	oldAfter := dateafter
 	oldBefore := datebefore
 	dateafter = "20250102"
@@ -86,7 +86,7 @@ func TestDateRangeOrderValidation(t *testing.T) {
 }
 
 func TestDateAfterFormatValidation(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	oldAfter := dateafter
 	oldBefore := datebefore
 	dateafter = "2025-01-01"
@@ -102,7 +102,7 @@ func TestDateAfterFormatValidation(t *testing.T) {
 }
 
 func TestDateBeforeFormatValidation(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	oldAfter := dateafter
 	oldBefore := datebefore
 	dateafter = "20250101"
@@ -118,7 +118,7 @@ func TestDateBeforeFormatValidation(t *testing.T) {
 }
 
 func TestDateRangeSameDayAllowed(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	oldAfter := dateafter
 	oldBefore := datebefore
 	oldRetries := retries
@@ -151,7 +151,7 @@ func TestDateRangeSameDayAllowed(t *testing.T) {
 }
 
 func TestMinIntervalValidation(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 	oldMinInterval := minInterval
@@ -164,7 +164,7 @@ func TestMinIntervalValidation(t *testing.T) {
 }
 
 func TestMaxPagesValidation(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 	oldMaxPages := maxPages
@@ -177,7 +177,7 @@ func TestMaxPagesValidation(t *testing.T) {
 }
 
 func TestMaxVideosValidation(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 	oldMaxVideos := maxVideos
@@ -208,7 +208,7 @@ func TestRunRootCmdInvalidInput(t *testing.T) {
 		isTerminal = origIsTerminal
 	})
 
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -221,7 +221,7 @@ func TestRunRootCmdInvalidInput(t *testing.T) {
 }
 
 func TestProgressAutoDisabledOnNonTTY(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -265,7 +265,7 @@ func TestProgressAutoDisabledOnNonTTY(t *testing.T) {
 }
 
 func TestProgressForcedOn(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -309,7 +309,7 @@ func TestProgressForcedOn(t *testing.T) {
 }
 
 func TestNoProgressOverridesForceProgress(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -353,7 +353,7 @@ func TestNoProgressOverridesForceProgress(t *testing.T) {
 }
 
 func TestRunRootCmdEmitsSummary(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -407,7 +407,7 @@ func TestRunRootCmdEmitsSummary(t *testing.T) {
 }
 
 func TestRunRootCmdStrictInvalidInputReturnsError(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -439,7 +439,7 @@ func TestRunRootCmdStrictInvalidInputReturnsError(t *testing.T) {
 }
 
 func TestRunRootCmdStrictInvalidStillOutputsValidResults(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -498,7 +498,7 @@ func TestRunRootCmdStrictInvalidStillOutputsValidResults(t *testing.T) {
 }
 
 func TestRunRootCmdBestEffortReturnsNilOnFetchError(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -549,7 +549,7 @@ func TestRunRootCmdBestEffortReturnsNilOnFetchError(t *testing.T) {
 }
 
 func TestRunRootCmdDedupeRemovesDuplicates(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -608,7 +608,7 @@ func TestRunRootCmdDedupeRemovesDuplicates(t *testing.T) {
 }
 
 func TestRunRootCmdJSONOutput(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -712,7 +712,7 @@ func TestRunRootCmdJSONOutput(t *testing.T) {
 }
 
 func TestRunRootCmdJSONOutputWithFetchError(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -819,7 +819,7 @@ func TestRunRootCmdJSONOutputWithFetchError(t *testing.T) {
 }
 
 func TestRunRootCmdJSONOutputTargetsSortedByTypeAndID(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 	user2Completed := make(chan struct{})
@@ -902,7 +902,7 @@ func TestRunRootCmdJSONOutputTargetsSortedByTypeAndID(t *testing.T) {
 }
 
 func TestRunRootCmdJSONOutputPreservesMylistTargetType(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -1010,7 +1010,7 @@ func TestSortTargetResultsSortsByTypeAndNumericID(t *testing.T) {
 }
 
 func TestRunRootCmdStrictOverridesBestEffort(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -1042,7 +1042,7 @@ func TestRunRootCmdStrictOverridesBestEffort(t *testing.T) {
 }
 
 func TestRunRootCmdInvalidInputNoOutput(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -1062,7 +1062,7 @@ func TestRunRootCmdInvalidInputNoOutput(t *testing.T) {
 }
 
 func TestRunRootCmdNoInputs(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 	inputFilePath = ""
@@ -1078,7 +1078,7 @@ func TestRunRootCmdNoInputs(t *testing.T) {
 }
 
 func TestRunRootCmdInputFileNoArgs(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -1120,7 +1120,7 @@ func TestRunRootCmdInputFileNoArgs(t *testing.T) {
 }
 
 func TestRunRootCmdStdinNoArgs(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -1207,7 +1207,7 @@ func TestStreamLinesFromFileReturnsCloseError(t *testing.T) {
 }
 
 func TestRunRootCmdReturnsLineOutputWriteError(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -1255,7 +1255,7 @@ func TestRunRootCmdReturnsLineOutputWriteError(t *testing.T) {
 }
 
 func TestRunRootCmdReturnsJSONOutputWriteError(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -1307,7 +1307,7 @@ func TestRunRootCmdReturnsJSONOutputWriteError(t *testing.T) {
 }
 
 func TestRunRootCmdReturnsSummaryWriteError(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -1347,7 +1347,7 @@ func TestRunRootCmdReturnsSummaryWriteError(t *testing.T) {
 }
 
 func TestRunRootCmdInputReadErrorCancelsFetches(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -1432,7 +1432,7 @@ func TestRunRootCmdInputReadErrorCancelsFetches(t *testing.T) {
 }
 
 func TestRunRootCmdInputFileReadErrorCancelsFetches(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -1524,7 +1524,7 @@ func TestRunRootCmdInputFileReadErrorCancelsFetches(t *testing.T) {
 }
 
 func TestRunRootCmdPartialFailureOutputsResults(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -1576,7 +1576,7 @@ func TestRunRootCmdPartialFailureOutputsResults(t *testing.T) {
 }
 
 func TestRunRootCmdLogFile(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -1629,7 +1629,7 @@ func TestRunRootCmdLogFile(t *testing.T) {
 }
 
 func TestRunRootCmdLogFileMultipleErrors(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 
@@ -1682,7 +1682,7 @@ func TestRunRootCmdLogFileMultipleErrors(t *testing.T) {
 }
 
 func TestConcurrencyValidation(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	concurrency = 0
 	t.Cleanup(func() { concurrency = 3 })
 
@@ -1694,7 +1694,7 @@ func TestConcurrencyValidation(t *testing.T) {
 }
 
 func TestRunRootCmdMylistInput(t *testing.T) {
-	logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger = slog.New(slog.DiscardHandler)
 	dateafter = "10000101"
 	datebefore = "99991231"
 

--- a/internal/niconico/client_test.go
+++ b/internal/niconico/client_test.go
@@ -480,7 +480,7 @@ func TestRetryAfterDelay(t *testing.T) {
 
 func TestGetVideoList(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		logger := slog.New(slog.DiscardHandler)
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			page := r.URL.Query().Get("page")
 			var resp string
@@ -512,7 +512,7 @@ func TestGetVideoList(t *testing.T) {
 	})
 
 	t.Run("before date is inclusive and next day is excluded", func(t *testing.T) {
-		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		logger := slog.New(slog.DiscardHandler)
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			if r.URL.Query().Get("page") != "1" {
@@ -537,7 +537,7 @@ func TestGetVideoList(t *testing.T) {
 	})
 
 	t.Run("invalid json", func(t *testing.T) {
-		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		logger := slog.New(slog.DiscardHandler)
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, "invalid")
@@ -556,7 +556,7 @@ func TestGetVideoList(t *testing.T) {
 }
 
 func TestGetVideoListContextCanceled(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"data":{"items":[]}}`)
@@ -580,7 +580,7 @@ func TestGetVideoListContextCanceled(t *testing.T) {
 }
 
 func TestGetVideoListHandleNotFound(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	count := 0
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		count++
@@ -606,7 +606,7 @@ func TestGetVideoListHandleNotFound(t *testing.T) {
 }
 
 func TestGetVideoListHandleServerError(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	count := 0
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		count++
@@ -629,7 +629,7 @@ func TestGetVideoListHandleServerError(t *testing.T) {
 }
 
 func TestGetVideoListPartialOnError(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		page := r.URL.Query().Get("page")
 		switch page {
@@ -657,7 +657,7 @@ func TestGetVideoListPartialOnError(t *testing.T) {
 }
 
 func TestGetVideoListMaxPagesStopsEarly(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	count := 0
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		count++
@@ -687,7 +687,7 @@ func TestGetVideoListMaxPagesStopsEarly(t *testing.T) {
 }
 
 func TestGetVideoListMaxVideosStopsEarly(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	count := 0
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		count++
@@ -740,7 +740,7 @@ func TestGetMylistVideoList(t *testing.T) {
 		nil,
 		0,
 		0,
-		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		slog.New(slog.DiscardHandler),
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/niconico/e2e_test.go
+++ b/internal/niconico/e2e_test.go
@@ -30,7 +30,7 @@ func TestGetVideoListE2E(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	ids, err := GetVideoList(
 		ctx,
 		userID,


### PR DESCRIPTION
## Summary

Enable `sloglint` in the golangci-lint gate.

## What / Why

Replaced test-only `slog.NewTextHandler(io.Discard, nil)` logger setup with `slog.DiscardHandler`, then added `sloglint` to `.golangci.yml`.

This keeps test logging discarded while enforcing consistent `log/slog` patterns going forward.

## Related issues

Closes #249

## Testing

```bash
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build GOLANGCI_LINT_CACHE=/tmp/go-nico-list-golangci-cache golangci-lint run --enable-only=sloglint ./...
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build GOLANGCI_LINT_CACHE=/tmp/go-nico-list-golangci-cache golangci-lint run ./...
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build go vet ./...
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build go test ./...
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build go test -race ./...
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build go generate ./...
GOPATH=/tmp/go-nico-list-go GOCACHE=/tmp/go-nico-list-go-build go mod tidy
git diff --exit-code
```

## Fix log

- 2026-05-21: initial implementation, replaced discard text handlers and enabled `sloglint`.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [ ] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [ ] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
