### PR TITLE
refactor: remove unreachable target fallback

### DIFF
--- a/cmd/root_run.go
+++ b/cmd/root_run.go
@@ -232,8 +232,6 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 				newList, err = niconico.GetVideoList(ctx, target.ID, comment, afterDate, beforeDate, baseURL, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger)
 			case targetTypeMylist:
 				newList, err = niconico.GetMylistVideoList(ctx, target.ID, comment, afterDate, beforeDate, baseURL, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger)
-			default:
-				err = fmt.Errorf("unsupported input target: %s", target.Type)
 			}
 			if err != nil {
 				atomic.AddInt64(&fetchErrCount, 1)


### PR DESCRIPTION
## Summary

Remove an unreachable fallback branch from command target dispatch.

## What / Why

`parseInputTarget` only produces `user` and `mylist` targets for valid inputs, so the `default` branch in `runRootCmd` cannot be reached in the current command flow. Removing it keeps the dispatch logic aligned with the parser invariant without changing user-facing behavior.

## Related issues

Closes #253

## Testing

```bash
GOCACHE=/tmp/go-nico-list-go-build GOMODCACHE=/tmp/go-nico-list-go-mod go test ./cmd -count=1
GOCACHE=/tmp/go-nico-list-go-build GOMODCACHE=/tmp/go-nico-list-go-mod go test ./cmd -run 'TestRunRootCmdJSONOutputTargetsSortedByTypeAndID|TestRunRootCmdJSONOutputPreservesMylistTargetType' -count=1
GOCACHE=/tmp/go-nico-list-go-build GOMODCACHE=/tmp/go-nico-list-go-mod go vet ./...
GOCACHE=/tmp/go-nico-list-go-build GOMODCACHE=/tmp/go-nico-list-go-mod go test ./...
GOCACHE=/tmp/go-nico-list-go-build GOMODCACHE=/tmp/go-nico-list-go-mod go test -race ./...
GOCACHE=/tmp/go-nico-list-go-build GOMODCACHE=/tmp/go-nico-list-go-mod go mod tidy
GOCACHE=/tmp/go-nico-list-go-build GOMODCACHE=/tmp/go-nico-list-go-mod go generate ./...
GOCACHE=/tmp/go-nico-list-go-build GOMODCACHE=/tmp/go-nico-list-go-mod GOLANGCI_LINT_CACHE=/tmp/go-nico-list-golangci-lint golangci-lint run ./...
git diff --exit-code -- go.mod go.sum THIRD_PARTY_NOTICES.md
git diff --exit-code -- . ':!.codex'
```

## Fix log

- 2026-05-21: Removed only the unreachable command target fallback after review; kept `NicoData.Series` as requested.
- 2026-05-21: Codex reviewer re-review returned `NO FINDINGS`.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [x] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
