### PR TITLE
docs: initialize AGENTS knowledge base

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,64 +1,128 @@
-# AGENTS
+# PROJECT KNOWLEDGE BASE
 
-Baseline rules for changes in this repository.
+**Generated from init-deep discovery:** 2026-06-03
+**Discovery base commit:** 4e6c57c
 
-## Development Rules (Checklist)
-- If you modify Go files, run `gofmt -w <files>` (or `gofmt -w .` to format everything).
-- After changes, run `go vet ./...` and confirm there are no errors.
-- After changes, run `go test ./...` and confirm there are no errors.
-- After changes, run `go test -race ./...` and confirm there are no errors.
-- Before opening a PR, verify generated-file drift checks stay clean: `go mod tidy`, `go generate ./...`, and `git diff --exit-code`.
-- If dependencies changed (`go.mod` / `go.sum`), run `bash scripts/gen-third-party-notices.sh` and ensure no drift in `THIRD_PARTY_NOTICES.md`.
-- Before implementation, create (or confirm) a GitHub Issue that tracks the work.
-- Keep issue scope atomic: one issue must map to one fix or one feature.
-- Use short-lived branches (e.g. `feature/*`) and merge via PR using **squash merge**; do not commit directly to `master` unless explicitly requested.
-- Implement only on the issue branch and merge via PR; never push implementation commits directly to `master`.
-- Use the `branch-helper` skill for tasks that modify the repository unless the user requests otherwise.
+## OVERVIEW
+`go-nico-list` is a Go 1.26.1 CLI that fetches niconico user/mylist video IDs, filters and sorts them, and writes machine-readable results to stdout while keeping progress, logs, summaries, and errors on stderr.
+
+## STRUCTURE
+```
+go-nico-list/
+|-- main.go                  # version resolution and cancellation-aware bootstrap
+|-- cmd/                     # Cobra flags, IO, validation, output, command tests
+|-- internal/niconico/        # API response types, fetch/retry/rate-limit/sort domain logic
+|-- docs/DESIGN.md           # canonical behavior and responsibility map
+|-- docs/README.ja.md        # Japanese README
+|-- scripts/                 # generated third-party notice tooling
+|-- .github/workflows/       # CI, release, latest-deps, generated-file refresh
+`-- .golangci.yml            # enabled linters
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+| --- | --- | --- |
+| CLI entrypoint | `main.go`, `cmd/root_flags.go` | `main` only wires version/context into `cmd.ExecuteContext`. |
+| Flags and defaults | `cmd/root_config.go` | `RootConfig`, `RootDeps`, `NewRootCommand`, normalization. |
+| Runtime flow | `cmd/root_run.go` | validation, input stream, goroutines, summary, output, error selection. |
+| Input parsing | `cmd/input_target.go`, `cmd/root_io.go` | URL regexes, stdin/input-file scanner, progress gating. |
+| JSON output | `cmd/root_json.go` | target ordering, flattened items, `--tab`/`--url` exclusion from JSON. |
+| API/domain logic | `internal/niconico/client.go` | fetch, pagination, retry, rate limit, response evaluation, sorting. |
+| API schema | `internal/niconico/nico_data.go` | `NicoData` decode target for fixtures and live API responses. |
+| Current behavior spec | `docs/DESIGN.md` | Update before user-facing/design-boundary implementation and get explicit OK. |
+| User docs | `README.md`, `docs/README.ja.md` | Update when user-facing behavior changes. |
+| PR shape | `.github/PULL_REQUEST_TEMPLATE.md` | Keep all sections; use `gh pr create --body-file`. |
+| CI parity | `.github/workflows/ci.yml` | Generated drift, notices, gofmt, vet, lint, test, race. |
+
+## CODE MAP
+| Symbol | Type | Location | Role |
+| --- | --- | --- | --- |
+| `main` | function | `main.go` | Resolve version and start the Cobra command with signal cancellation. |
+| `RootConfig` | struct | `cmd/root_config.go` | All flag values and runtime defaults. |
+| `RootDeps` | struct | `cmd/root_config.go` | Injectable IO/logger/progress/file dependencies for tests. |
+| `NewRootCommand` | function | `cmd/root_config.go` | Builds the root Cobra command and attaches `RunE`. |
+| `runRootCmdWithConfig` | function | `cmd/root_run.go` | Main command runner and aggregation boundary. |
+| `streamInputsWithConfig` | function | `cmd/root_io.go` | Merges args, `--input-file`, and `--stdin` into a target stream. |
+| `buildJSONOutput` | function | `cmd/root_json.go` | Builds the stdout JSON payload. |
+| `parseInputTarget` | function | `cmd/input_target.go` | Extracts first matching niconico user/mylist target. |
+| `GetVideoList` | function | `internal/niconico/client.go` | Fetches filtered user video IDs. |
+| `GetMylistVideoList` | function | `internal/niconico/client.go` | Fetches filtered mylist video IDs. |
+| `collectVideoList` | function | `internal/niconico/client.go` | Shared pagination/filter/cap loop. |
+| `retriesRequest` | function | `internal/niconico/client.go` | HTTP retry, rate-limit, timeout, and retry-after handling. |
+| `NiconicoSort` | function | `internal/niconico/client.go` | Sorts raw `sm*` IDs by numeric part. |
+| `RateLimiter.Wait` | method | `internal/niconico/client.go` | Global request pacing across concurrent fetches and retries. |
+
+## DEVELOPMENT RULES
+- Before implementation, create or confirm a GitHub Issue. Keep one issue scoped to one fix or one feature.
+- Use `branch-helper` for repository-modifying tasks unless explicitly told otherwise.
+- Work on a short-lived branch and merge through a PR using squash merge. Never push implementation commits directly to `master`.
+- Create the PR right after the initial implementation commit so the fix log can be maintained in the PR body.
+- PR bodies must use `.github/PULL_REQUEST_TEMPLATE.md`, keep all sections, and include an auto-close keyword such as `Closes #123`.
+- When editing PR bodies with `gh`, rewrite the full body with `-F <file>`.
+- Maintain the PR fix log after each correction pass.
+- For implementation work, follow Implement -> Test -> Review. If review findings need confirmation, ask numbered questions first; after answers, repeat Fix -> Test -> Review until there are no findings.
 - After addressing review feedback, ask Codex for a re-review in chat.
-- PRs must include an auto-close keyword for related issues (e.g. `Closes #123`).
-- PR bodies must be based on `.github/PULL_REQUEST_TEMPLATE.md` and keep all sections.
-- When creating PRs with `gh`, always use `--body-file` from the template (avoid `--fill` alone).
-- Create the PR right after the initial implementation commit so fix logs can be tracked in the PR body.
-- Maintain a running fix log in the PR body after each correction pass.
-- When editing PR bodies with `gh`, use `-F <file>` and rewrite the full body (no `--add-body` flag exists).
-- For implementation work, always follow this flow: Implement → Test → Review.
-  - If the review has findings, ask numbered questions for any confirmations needed.
-  - Once confirmations are resolved, apply fixes and repeat Fix → Test → Review until there are no findings.
+- Avoid interactive editors in automated merges. Use non-interactive `gh pr merge --squash` patterns and set `GIT_EDITOR` when needed.
+- Before merging, wait for all CI checks to complete with `gh pr checks --watch` unless explicitly told to skip.
+- When handling multiple PRs, create all PRs first, then confirm CI and merge together at the end.
 
-## Workflow Notes
-- Keep tests deterministic; avoid time-based ordering and use controllable IO (e.g. pipes) when sequencing matters.
-- When mocking the niconico API, ensure pagination terminates (e.g. return empty items or 404 for page > 1).
-- Avoid interactive editors in automated merges (use `gh pr merge --squash` and set `GIT_EDITOR` to a non-interactive command when needed).
-- Before merging, wait for all CI checks to complete (use `gh pr checks --watch`) unless explicitly told to skip.
-- When handling multiple pull requests, create all PRs first, then run CI confirmation and merge operations together at the end.
-- When a versioned milestone is completed, release using the same version number; after the release workflow succeeds, close the milestone.
-- `master` is protected by repository rulesets: PR-only updates, required conversation resolution, required `go-ci`, and squash-only merge method.
-- Release tags (`refs/tags/v*`) are protected by repository rulesets that control tag create/update/delete operations.
+## CHANGE RULES
+- Keep changes atomic and limited to the issue scope.
+- Do not mix CLI and domain logic. `cmd/` handles flags, IO, validation, output, concurrency, and exit behavior; `internal/niconico/` handles API fetch/retry/sort/types.
+- Refactors must preserve flags, stdout/stderr, log messages, summaries, exit codes, progress behavior, pagination, retry, and rate-limit semantics unless the issue explicitly changes them.
+- Before user-facing behavior or responsibility-boundary changes, update `docs/DESIGN.md` as needed and get explicit OK before implementation.
+- For internal-only changes, such as CI, docs, or process-only updates, `docs/DESIGN.md` changes are not required.
+- If user-facing behavior changes, update `README.md` and `docs/README.ja.md` as appropriate.
+- Keep undecided proposals out of `docs/DESIGN.md`; record backlog ideas in GitHub Issues.
+- Keep `README.md`, `docs/DESIGN.md`, and `AGENTS.md` in English.
+- Keep `WORKLOG.md` local-only, English, and uncommitted.
 
-## Design
-Refer to `docs/DESIGN.md` for the design overview and responsibility boundaries.
-Keep `docs/DESIGN.md` up-to-date with the current code and behavior.
-Before implementing user-facing behavior changes or design-boundary changes, update `docs/DESIGN.md` as needed and get explicit confirmation (OK) before implementing.
-For internal-only changes (for example CI/docs/process-only updates), `docs/DESIGN.md` updates are not required.
-If user-facing behavior changes, update `README.md` as well.
+## TESTING
+- If Go files change, run `gofmt -w <files>`.
+- After changes, run:
+```bash
+go vet ./...
+go test ./...
+go test -race ./...
+```
+- Before opening a PR, verify generated-file drift:
+```bash
+go mod tidy
+go generate ./...
+git diff --exit-code
+```
+- CI also runs:
+```bash
+golangci-lint run ./...
+bash scripts/gen-third-party-notices.sh
+git diff --exit-code -- THIRD_PARTY_NOTICES.md
+```
+- For local work, run `bash scripts/gen-third-party-notices.sh` when dependencies changed or when doing full PR parity verification.
+- Optional targeted layers live in `CONTRIBUTING.md`: contract fixture decode, fuzz smoke, E2E with `GO_NICO_LIST_E2E_USER_ID`, and the sort benchmark.
 
-## Improvements / Backlog
-Keep `docs/DESIGN.md` focused on the current, agreed-upon behavior.
-Do not add undecided proposals to `docs/DESIGN.md`.
-Record undecided proposals and improvement ideas in GitHub Issues.
+## TEST PATTERNS
+- Keep tests deterministic; avoid time-based ordering unless controlled with injectable time, pipes, contexts, or test servers.
+- CLI tests are split by behavior under `cmd/root_*_test.go` and use helpers from `cmd/root_test_helpers_test.go`.
+- Use `httptest.Server` for command/API integration tests and assert stdout, stderr, and returned errors separately.
+- When mocking niconico pagination, terminate page > 1 with empty items or 404.
+- Contract fixtures live under `internal/niconico/testdata/` and are decoded by `internal/niconico/nico_data_contract_test.go`.
+- Fuzz tests cover parse, regex submatch, sort, and JSON unmarshal panic safety.
+- E2E tests are opt-in behind the `e2e` build tag and `GO_NICO_LIST_E2E_USER_ID`.
 
-## Work Log
-Use `WORKLOG.md` (git-ignored) to record interrupted work, session status, and next steps.
-Do not commit `WORKLOG.md`; keep it local-only.
-Keep `WORKLOG.md` in English.
+## ANTI-PATTERNS
+- Do not add runtime dependencies without prior approval.
+- Do not commit `WORKLOG.md`, `.omo/`, `.codex/`, local caches, or continuation artifacts.
+- Do not write progress, logs, summaries, or errors to stdout. Data output belongs on stdout; operational output belongs on stderr or the logfile.
+- Do not assume fetch/log order is deterministic; concurrency makes first error and log order nondeterministic.
+- Do not leave response bodies unclosed on early HTTP-status handling paths.
+- Do not bypass `Retry-After`, global rate limiting, context cancellation, or safety caps when touching fetch logic.
+- Do not update release tags or push directly to `master`; both are protected by repository rulesets.
+- When a versioned milestone is completed, release using the same version number and close the milestone after the release workflow succeeds.
 
-## Dependencies
-Ask for approval before adding new runtime (production) dependencies.
-
-## Review Questions
-When a review has findings, always ask confirmation questions for all findings.
-Do not implement changes related to those findings until answers are received.
-Number each question to make responses easier.
-
-## Documentation Language
-Keep `README.md`, `docs/DESIGN.md`, and `AGENTS.md` in English.
+## COMMIT MESSAGES
+- Use `type: summary` with allowed types `feat`, `fix`, `docs`, `ci`, `chore`, `refactor`, `test`, `build`.
+- For complex changes, add details after a blank line.
+- When Codex is used, add:
+```
+AI-Assisted: Codex
+```

--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -1,0 +1,47 @@
+# CMD PACKAGE GUIDE
+
+## OVERVIEW
+`cmd/` owns the Cobra command surface: flags, runtime config, input streams, stdout/stderr behavior, progress, logging, concurrency, summaries, and command-level tests.
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+| --- | --- | --- |
+| Public command entry | `root_flags.go` | `Execute`, `ExecuteContext`, and package `Version`. |
+| Flags/defaults/deps | `root_config.go` | `RootConfig`, `RootDeps`, `DefaultConfig`, `DefaultDeps`, `NewRootCommand`. |
+| Runner | `root_run.go` | Validation, goroutine fan-out, fetch aggregation, summary, output, final error. |
+| Input targets | `input_target.go` | Partial-match user/mylist regexes and named submatch extraction. |
+| Input streams/progress | `root_io.go` | Args/input-file/stdin merge, scanner limit, progress auto-disable. |
+| JSON output | `root_json.go` | JSON schema, target ordering, normalized item output. |
+| Test harness | `root_test_helpers_test.go` | Shared `httptest`, command runner, buffers, fake readers/writers. |
+
+## BOUNDARIES
+- Keep niconico HTTP, pagination, retry, rate-limit, filtering, and raw ID sorting in `internal/niconico`.
+- Keep command concerns here: flag validation, input source handling, output formatting, exit-code selection, logging destination, progress visibility, and dependency injection.
+- `RootConfig` should remain the single place for flag values and runtime defaults.
+- `RootDeps` should remain the injection surface for IO, logging, progress factories, input files, and terminal detection.
+- `runRootCmdWithConfig` is the command runner. Split helpers only when they preserve observable CLI behavior.
+
+## OUTPUT RULES
+- stdout is only data: line output or one JSON object.
+- stderr is for progress, warnings, summaries, Cobra error text, and logs unless `--logfile` is set.
+- `--json` disables line output; `--tab` and `--url` do not alter JSON `items`.
+- `--strict` takes precedence over `--best-effort`.
+- Fetch errors can still produce partial stdout results.
+- Invalid inputs are skipped by default; `--strict` makes them non-zero while preserving valid results.
+- Progress auto-disables on non-TTY stderr; `--no-progress` overrides `--progress`.
+
+## TEST PATTERNS
+- Add command tests as focused `root_*_test.go` files near the behavior they cover.
+- Use `newTestRootConfig`, `newTestRootDeps`, `executeTestRootCommand`, or `testRunner` from `root_test_helpers_test.go`.
+- Use `httptest.Server` for fetch-facing command tests instead of live API calls.
+- Assert stdout and stderr separately; summaries belong on stderr.
+- For concurrency-sensitive tests, use controllable synchronization (`sync.Once`, channels, context cancellation) instead of sleeping.
+- Cover writer, reader, and close errors when touching IO paths.
+- Keep JSON tests decoding the payload rather than comparing large raw strings.
+
+## GOTCHAS
+- Input regexes are partial matches and prefer the first matching target pattern.
+- `bufio.Scanner` input lines are capped at 1 MiB.
+- Fetch/log order and first returned fetch error are nondeterministic because targets run concurrently.
+- Cobra should not print usage for validation failures.
+- If `--logfile` is set, log output moves to the file but Cobra can still print the returned error to stderr.

--- a/internal/niconico/AGENTS.md
+++ b/internal/niconico/AGENTS.md
@@ -1,0 +1,49 @@
+# NICONICO DOMAIN GUIDANCE
+
+Scope: files under `internal/niconico/`.
+
+## Boundary
+- Keep this package focused on niconico domain behavior: API request construction, response decoding, pagination, filtering, retry, rate limiting, and raw video ID sorting.
+- Do not add Cobra, terminal, stdout/stderr, progress, CLI flag parsing, or exit-code behavior here; those belong in `cmd/`.
+- Public entry points are `GetVideoList`, `GetMylistVideoList`, `NiconicoSort`, `NewRateLimiter`, and `RateLimiter.Wait`.
+
+## Key Files
+- `client.go`: user/mylist fetch entry points, shared collection loop, retry/backoff, `Retry-After`, rate limiting, response body handling, and sorting.
+- `nico_data.go`: decode target for user-video API responses and fixture contract tests.
+- `client_test.go`: low-level behavior coverage for fetch, retry, backoff, cancellation, timeout, 404 handling, and rate limiting.
+- `nico_data_contract_test.go`: fixture-backed API shape contract.
+- `fuzz_test.go`: panic-safety coverage for sorting and JSON decode boundaries.
+- `e2e_test.go`: opt-in live API coverage behind the `e2e` build tag and `GO_NICO_LIST_E2E_USER_ID`.
+- `benchmark_test.go`: `NiconicoSort` performance baseline.
+
+## Fetch Invariants
+- User endpoint format is `<baseURL>/users/<userID>/videos?pageSize=100&page=<n>`.
+- Mylist endpoint format is `<baseURL>/mylists/<mylistID>?pageSize=100&page=<n>`.
+- Requests must set `X-Frontend-Id: 6` and `Accept: */*`.
+- Pagination starts at page 1 and stops on 404, empty items, `maxPages`, or `maxVideos`.
+- `maxPages` and `maxVideos` are best-effort caps and should not produce errors by themselves.
+- Context cancellation or deadline during fetch is treated by collection as a clean empty result.
+- HTTP 200 with non-200 `meta.status` logs a warning and continues as a successful response.
+- Returned IDs stay raw `sm*` values; formatting is a `cmd` concern.
+
+## Retry And Body Handling
+- Retry any HTTP status other than 200 or 404.
+- Honor HTTP 429 `Retry-After`; wait for the longer of `Retry-After` and computed backoff/interval delay.
+- Apply global rate limiting before every request attempt, including retries.
+- Exponential backoff starts at 100ms and is capped at 30s.
+- Do not sleep after the final attempt.
+- Always close response bodies on discarded responses and early status-handling paths, including 404 and retry statuses.
+- Preserve context-aware sleeps so cancellation interrupts backoff and rate-limit waits.
+
+## Filtering And Sorting
+- Include only items with `comment > commentCount`.
+- Include dates from `dateafter` through `datebefore` inclusive; the current implementation uses an exclusive `beforeDate.AddDate(0, 0, 1)` upper bound.
+- `NiconicoSort` sorts by the numeric part of video IDs using a total-order fallback for malformed or very large values.
+- Do not format, dedupe, or prefix IDs in this package.
+
+## Testing Patterns
+- Use `httptest.Server` for network behavior and keep pagination finite.
+- Add fixture fields intentionally. If live API shape changes, update `testdata/` and `nico_data_contract_test.go` together.
+- For retry, rate-limit, and backoff tests, use existing injectable time/sleep hooks instead of wall-clock waits.
+- Fuzz tests should protect against panics, not encode detailed business assertions.
+- E2E tests are opt-in only and must not be required for normal CI.


### PR DESCRIPTION
## Summary

Initialize the hierarchical AGENTS.md knowledge base for the repository.

## What / Why

- Expand the root `AGENTS.md` into an init-deep project knowledge base while preserving repository workflow rules.
- Add package-scoped guidance for `cmd/` and `internal/niconico/` so future agents can quickly find boundaries, invariants, and test patterns.
- Keep generated guidance tied to current repository files, CI, and design docs rather than generic Go advice.

## Related issues

Closes #257

## Testing

```bash
git diff --check
go mod tidy
go generate ./...
go vet ./...
go test ./...
go test -race ./...
golangci-lint run ./...
bash scripts/gen-third-party-notices.sh
```

Also verified referenced local files exist and `go.mod`, `go.sum`, and `THIRD_PARTY_NOTICES.md` had no drift after generation/notice checks.

## Fix log

- 2026-06-03: initialize root and package-scoped AGENTS.md files.
- 2026-06-03: address review feedback by clarifying discovery metadata and local third-party notices usage.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .` (not applicable; no Go files changed)
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed (not applicable; no behavior change)
- [x] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed (not applicable; no dependency change; drift check passed)
