### PR TITLE
perf: reduce hot-path allocations

### DIFF
--- a/cmd/root_benchmark_test.go
+++ b/cmd/root_benchmark_test.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func BenchmarkBuildJSONOutputLarge(b *testing.B) {
+	targets := make([]targetResult, 100)
+	outputIDs := make([]string, 0, 5000)
+	for i := range targets {
+		items := make([]string, 50)
+		for j := range items {
+			items[j] = fmt.Sprintf("sm%d", i*50+j)
+		}
+		targets[i] = targetResult{Type: targetTypeUser, ID: fmt.Sprintf("%d", i), Items: items}
+		outputIDs = append(outputIDs, items...)
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		payload := buildJSONOutput(100, 100, 0, nil, targets, nil, len(outputIDs), outputIDs)
+		if payload.OutputCount != len(outputIDs) {
+			b.Fatalf("unexpected output_count: %d", payload.OutputCount)
+		}
+	}
+}
+
+func BenchmarkSortTargetResultsLarge(b *testing.B) {
+	base := make([]targetResult, 2000)
+	for i := range base {
+		targetType := targetTypeUser
+		if i%2 == 0 {
+			targetType = targetTypeMylist
+		}
+		id := fmt.Sprintf("%d", 2000-i)
+		if i%5 == 0 {
+			id = fmt.Sprintf("%d-invalid", i)
+		}
+		base[i] = targetResult{Type: targetType, ID: id, Error: fmt.Sprintf("err-%d", i)}
+	}
+	results := make([]targetResult, len(base))
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		copy(results, base)
+		sortTargetResults(results)
+	}
+}
+
+func BenchmarkRunRootCmdLargeFanInLineOutput(b *testing.B) {
+	server := newBenchmarkAPIServer(b)
+	cfg := testFetchConfig(server.URL)
+	cfg.NoProgress = true
+	args := []string{"nicovideo.jp/user/1", "nicovideo.jp/user/2", "nicovideo.jp/mylist/847130"}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		deps := newTestRootDeps()
+		deps.Stdout = io.Discard
+		deps.Stderr = io.Discard
+		err := executeBenchmarkRootCommand(cfg, deps, args...)
+		if err != nil {
+			b.Fatalf("command returned error: %v", err)
+		}
+	}
+}
+
+func BenchmarkRunRootCmdLargeFanInJSONOutput(b *testing.B) {
+	server := newBenchmarkAPIServer(b)
+	cfg := testFetchConfig(server.URL)
+	cfg.NoProgress = true
+	cfg.JSONOutput = true
+	args := []string{"nicovideo.jp/user/1", "nicovideo.jp/user/2", "nicovideo.jp/mylist/847130"}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		deps := newTestRootDeps()
+		deps.Stdout = io.Discard
+		deps.Stderr = io.Discard
+		err := executeBenchmarkRootCommand(cfg, deps, args...)
+		if err != nil {
+			b.Fatalf("command returned error: %v", err)
+		}
+	}
+}
+
+func executeBenchmarkRootCommand(cfg RootConfig, deps RootDeps, args ...string) error {
+	cmd := NewRootCommand(cfg, deps)
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func newBenchmarkAPIServer(b *testing.B) *httptest.Server {
+	b.Helper()
+	userPayload := benchmarkUserPayload(100)
+	mylistPayload := benchmarkMylistPayload(100)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") != "1" {
+			if r.URL.Path == "/mylists/847130" {
+				_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"items":[]}}}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+			return
+		}
+		if r.URL.Path == "/mylists/847130" {
+			_, _ = io.WriteString(w, mylistPayload)
+			return
+		}
+		_, _ = io.WriteString(w, userPayload)
+	}))
+	b.Cleanup(server.Close)
+	return server
+}
+
+func benchmarkUserPayload(count int) string {
+	payload := `{"meta":{"status":200},"data":{"items":[`
+	for i := range count {
+		if i > 0 {
+			payload += ","
+		}
+		payload += fmt.Sprintf(`{"essential":{"id":"sm%d","registeredAt":"2024-01-02T03:04:05Z","count":{"comment":12}}}`, i)
+	}
+	return payload + `]}}`
+}
+
+func benchmarkMylistPayload(count int) string {
+	payload := `{"meta":{"status":200},"data":{"mylist":{"items":[`
+	for i := range count {
+		if i > 0 {
+			payload += ","
+		}
+		payload += fmt.Sprintf(`{"video":{"id":"sm%d","registeredAt":"2024-01-02T03:04:05Z","count":{"comment":12}}}`, i)
+	}
+	return payload + `]}}}`
+}

--- a/cmd/root_json.go
+++ b/cmd/root_json.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"sort"
-	"strconv"
 	"strings"
 )
 
@@ -77,16 +76,8 @@ func sortTargetResults(results []targetResult) {
 		if results[i].Type != results[j].Type {
 			return results[i].Type < results[j].Type
 		}
-		leftID, leftErr := strconv.ParseUint(results[i].ID, 10, 64)
-		rightID, rightErr := strconv.ParseUint(results[j].ID, 10, 64)
-		if leftErr == nil && rightErr == nil && leftID != rightID {
-			return leftID < rightID
-		}
-		if leftErr == nil && rightErr != nil {
-			return true
-		}
-		if leftErr != nil && rightErr == nil {
-			return false
+		if less, decided := targetIDLess(results[i].ID, results[j].ID); decided {
+			return less
 		}
 		if results[i].ID != results[j].ID {
 			return results[i].ID < results[j].ID
@@ -94,6 +85,46 @@ func sortTargetResults(results []targetResult) {
 		return results[i].Error < results[j].Error
 	})
 }
+
+// targetIDLess compares target IDs using numeric order when both fit uint64.
+func targetIDLess(leftID string, rightID string) (bool, bool) {
+	left, leftNumeric := normalizedTargetUint64Text(leftID)
+	right, rightNumeric := normalizedTargetUint64Text(rightID)
+	if leftNumeric && rightNumeric && left != right {
+		if len(left) != len(right) {
+			return len(left) < len(right), true
+		}
+		return left < right, true
+	}
+	if leftNumeric && !rightNumeric {
+		return true, true
+	}
+	if !leftNumeric && rightNumeric {
+		return false, true
+	}
+	return false, false
+}
+
+// normalizedTargetUint64Text returns canonical decimal text when text fits uint64.
+func normalizedTargetUint64Text(text string) (string, bool) {
+	if len(text) == 0 || len(text) > len(maxTargetUint64Text) {
+		return text, false
+	}
+	for i := range text {
+		if text[i] < '0' || text[i] > '9' {
+			return text, false
+		}
+	}
+	if len(text) == len(maxTargetUint64Text) && text > maxTargetUint64Text {
+		return text, false
+	}
+	for len(text) > 1 && text[0] == '0' {
+		text = text[1:]
+	}
+	return text, true
+}
+
+const maxTargetUint64Text = "18446744073709551615"
 
 // normalizeOutputID strips tab and URL prefixes from an output ID.
 func normalizeOutputID(id string) string {

--- a/cmd/root_json_sort_test.go
+++ b/cmd/root_json_sort_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSortTargetResultsLargeAllocationBudget(t *testing.T) {
+	base := make([]targetResult, 2000)
+	for i := range base {
+		targetType := targetTypeUser
+		if i%2 == 0 {
+			targetType = targetTypeMylist
+		}
+		id := fmt.Sprintf("%d", 2000-i)
+		if i%5 == 0 {
+			id = fmt.Sprintf("%d-invalid", i)
+		}
+		base[i] = targetResult{Type: targetType, ID: id, Error: fmt.Sprintf("err-%d", i)}
+	}
+
+	allocs := testing.AllocsPerRun(20, func() {
+		results := append([]targetResult(nil), base...)
+		sortTargetResults(results)
+	})
+
+	const allocationBudget = 25
+	if allocs > allocationBudget {
+		t.Fatalf("allocation budget exceeded: got %.0f allocs, want <= %d", allocs, allocationBudget)
+	}
+}

--- a/cmd/root_line_output.go
+++ b/cmd/root_line_output.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"bufio"
+	"io"
+)
+
+// writeLineOutput writes line output directly without building a joined string.
+func writeLineOutput(out io.Writer, items []string, withTab bool, withURL bool) error {
+	if len(items) == 0 {
+		return nil
+	}
+	writer := bufio.NewWriter(out)
+	for _, item := range items {
+		if withTab {
+			if _, err := io.WriteString(writer, tabOutputPrefix); err != nil {
+				return err
+			}
+		}
+		if withURL {
+			if _, err := io.WriteString(writer, nicoWatchURLPrefix); err != nil {
+				return err
+			}
+		}
+		if _, err := io.WriteString(writer, item); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(writer, "\n"); err != nil {
+			return err
+		}
+	}
+	return writer.Flush()
+}

--- a/cmd/root_output_test.go
+++ b/cmd/root_output_test.go
@@ -3,12 +3,81 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+func TestWriteLineOutputMatchesExistingFormatting(t *testing.T) {
+	tests := []struct {
+		name    string
+		tab     bool
+		url     bool
+		want    string
+		wantNil bool
+	}{
+		{name: "raw", want: "sm1\nsm2\n"},
+		{name: "tab", tab: true, want: tabOutputPrefix + "sm1\n" + tabOutputPrefix + "sm2\n"},
+		{name: "url", url: true, want: nicoWatchURLPrefix + "sm1\n" + nicoWatchURLPrefix + "sm2\n"},
+		{name: "tab and url", tab: true, url: true, want: tabOutputPrefix + nicoWatchURLPrefix + "sm1\n" + tabOutputPrefix + nicoWatchURLPrefix + "sm2\n"},
+		{name: "empty", wantNil: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			items := []string{"sm1", "sm2"}
+			if tt.wantNil {
+				items = nil
+			}
+
+			if err := writeLineOutput(&out, items, tt.tab, tt.url); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := out.String(); got != tt.want {
+				t.Fatalf("unexpected output: got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteLineOutputReturnsWriterError(t *testing.T) {
+	writeErr := errors.New("stdout failed")
+
+	err := writeLineOutput(errorWriter{err: writeErr}, []string{"sm1"}, false, false)
+
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("expected stdout error, got %v", err)
+	}
+}
+
+func TestWriteLineOutputBatchesWrites(t *testing.T) {
+	var out countingWriter
+	items := make([]string, 100)
+	for i := range items {
+		items[i] = fmt.Sprintf("sm%d", i)
+	}
+
+	if err := writeLineOutput(&out, items, true, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.writes > 2 {
+		t.Fatalf("expected batched writes, got %d writes", out.writes)
+	}
+}
+
+type countingWriter struct {
+	buf    bytes.Buffer
+	writes int
+}
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	w.writes++
+	return w.buf.Write(p)
+}
 
 func TestRunRootCmdEmitsSummary(t *testing.T) {
 	server := newEmptyAPIServer(t)

--- a/cmd/root_run.go
+++ b/cmd/root_run.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -89,25 +88,6 @@ func outWriterFor(cmd *cobra.Command) io.Writer {
 		return os.Stdout
 	}
 	return cmd.OutOrStdout()
-}
-
-// formatOutputIDs applies optional tab/url prefixes for line output.
-func formatOutputIDs(items []string, withTab bool, withURL bool) []string {
-	if !withTab && !withURL {
-		return items
-	}
-	prefix := ""
-	if withTab {
-		prefix += tabOutputPrefix
-	}
-	if withURL {
-		prefix += nicoWatchURLPrefix
-	}
-	formatted := make([]string, 0, len(items))
-	for _, item := range items {
-		formatted = append(formatted, prefix+item)
-	}
-	return formatted
 }
 
 func runRootCmdWithConfig(cmd *cobra.Command, args []string, cfg *RootConfig, deps RootDeps) (retErr error) {
@@ -309,8 +289,7 @@ func runRootCmdWithConfig(cmd *cobra.Command, args []string, cfg *RootConfig, de
 			outputErr = err
 		}
 	} else if outputCount > 0 {
-		formattedIDs := formatOutputIDs(outputIDs, cfg.Tab, cfg.URL)
-		if _, err := fmt.Fprintln(out, strings.Join(formattedIDs, "\n")); err != nil {
+		if err := writeLineOutput(out, outputIDs, cfg.Tab, cfg.URL); err != nil {
 			outputErr = err
 		}
 	}

--- a/internal/niconico/benchmark_test.go
+++ b/internal/niconico/benchmark_test.go
@@ -1,8 +1,14 @@
 package niconico
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func BenchmarkNiconicoSort(b *testing.B) {
@@ -21,3 +27,107 @@ func BenchmarkNiconicoSort(b *testing.B) {
 		NiconicoSort(values)
 	}
 }
+
+func BenchmarkNiconicoSortLargeMixed(b *testing.B) {
+	base := make([]string, 2000)
+	for i := range base {
+		switch i % 4 {
+		case 0:
+			base[i] = fmt.Sprintf("sm%d", 2000-i)
+		case 1:
+			base[i] = fmt.Sprintf("sm%012d", i)
+		case 2:
+			base[i] = fmt.Sprintf("xx%d", 4000-i)
+		default:
+			base[i] = fmt.Sprintf("sm%dextra", i)
+		}
+	}
+	values := make([]string, len(base))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		copy(values, base)
+		b.StartTimer()
+		NiconicoSort(values)
+	}
+}
+
+func BenchmarkGetVideoListLargeUserPayload(b *testing.B) {
+	payload := largeUserPayload(100)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") != "1" {
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+			return
+		}
+		_, _ = io.WriteString(w, payload)
+	}))
+	b.Cleanup(server.Close)
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC)
+	logger := slog.New(slog.DiscardHandler)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ids, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+		if err != nil {
+			b.Fatalf("GetVideoList returned error: %v", err)
+		}
+		if len(ids) != 100 {
+			b.Fatalf("expected 100 ids, got %d", len(ids))
+		}
+	}
+}
+
+func BenchmarkGetMylistVideoListLargePayload(b *testing.B) {
+	payload := largeMylistPayload(100)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") != "1" {
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"items":[]}}}`)
+			return
+		}
+		_, _ = io.WriteString(w, payload)
+	}))
+	b.Cleanup(server.Close)
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC)
+	logger := slog.New(slog.DiscardHandler)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ids, err := GetMylistVideoList(context.Background(), "847130", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+		if err != nil {
+			b.Fatalf("GetMylistVideoList returned error: %v", err)
+		}
+		if len(ids) != 100 {
+			b.Fatalf("expected 100 ids, got %d", len(ids))
+		}
+	}
+}
+
+func largeUserPayload(count int) string {
+	payload := `{"meta":{"status":200},"data":{"items":[`
+	for i := range count {
+		if i > 0 {
+			payload += ","
+		}
+		payload += fmt.Sprintf(`{"essential":{"id":"sm%d","registeredAt":"2024-01-02T03:04:05Z","count":{"comment":12},"title":"%s","description":"%s"}}`, i, benchmarkText, benchmarkText)
+	}
+	return payload + `]}}`
+}
+
+func largeMylistPayload(count int) string {
+	payload := `{"meta":{"status":200},"data":{"mylist":{"items":[`
+	for i := range count {
+		if i > 0 {
+			payload += ","
+		}
+		payload += fmt.Sprintf(`{"video":{"id":"sm%d","registeredAt":"2024-01-02T03:04:05Z","count":{"comment":12},"title":"%s","description":"%s"}}`, i, benchmarkText, benchmarkText)
+	}
+	return payload + `]}}}`
+}
+
+const benchmarkText = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"

--- a/internal/niconico/client.go
+++ b/internal/niconico/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -29,45 +28,6 @@ type videoItem struct {
 	ID           string
 	CommentCount int
 	RegisteredAt time.Time
-}
-
-// videoIDSortKey stores a total-order key for a video ID.
-type videoIDSortKey struct {
-	length int
-	text   string
-}
-
-// NiconicoSort sorts video IDs by their numeric part in ascending order.
-func NiconicoSort(slice []string) {
-	sort.Slice(slice, func(i, j int) bool {
-		left := videoIDSortKeyFor(slice[i])
-		right := videoIDSortKeyFor(slice[j])
-		if left.length != right.length {
-			return left.length < right.length
-		}
-		if left.text != right.text {
-			return left.text < right.text
-		}
-		return slice[i] < slice[j]
-	})
-}
-
-// videoIDSortKeyFor returns a total-order key for a video ID.
-func videoIDSortKeyFor(id string) videoIDSortKey {
-	text := videoIDSortText(id)
-	if n, err := strconv.ParseUint(text, 10, 64); err == nil {
-		text = strconv.FormatUint(n, 10)
-	}
-	return videoIDSortKey{length: len(text), text: text}
-}
-
-// videoIDSortText returns the comparable text portion of a video ID.
-func videoIDSortText(id string) string {
-	const prefixLen = 2
-	if len(id) >= prefixLen {
-		return id[prefixLen:]
-	}
-	return id
 }
 
 // GetVideoList retrieves video IDs for a user.

--- a/internal/niconico/client_test.go
+++ b/internal/niconico/client_test.go
@@ -29,45 +29,6 @@ func (r *trackingReadCloser) Close() error {
 	return nil
 }
 
-func TestNiconicoSort(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    []string
-		expected []string
-	}{
-		{
-			name:     "simple",
-			input:    []string{"sm12", "sm3", "sm1"},
-			expected: []string{"sm1", "sm3", "sm12"},
-		},
-		{
-			name:     "shortString",
-			input:    []string{"sm12", "s", "sm3"},
-			expected: []string{"sm3", "s", "sm12"},
-		},
-		{
-			name:     "longNumericIDs",
-			input:    []string{"sm100000000", "sm99999999", "sm3"},
-			expected: []string{"sm3", "sm99999999", "sm100000000"},
-		},
-		{
-			name:     "malformedWithLongNumericIDs",
-			input:    []string{"sm100000000", "xx200000000a", "sm99999999"},
-			expected: []string{"sm99999999", "sm100000000", "xx200000000a"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			slice := append([]string(nil), tt.input...)
-			NiconicoSort(slice)
-			if !reflect.DeepEqual(slice, tt.expected) {
-				t.Errorf("%s: expected %v, got %v", tt.name, tt.expected, slice)
-			}
-		})
-	}
-}
-
 func TestCloseAndIsNotFound(t *testing.T) {
 	t.Run("not found closes body", func(t *testing.T) {
 		body := &trackingReadCloser{}
@@ -301,8 +262,7 @@ func TestNewRateLimiterInterval(t *testing.T) {
 			}
 			if limiter == nil {
 				t.Fatal("expected limiter, got nil")
-			}
-			if limiter.interval != tt.want {
+			} else if limiter.interval != tt.want {
 				t.Errorf("expected interval %v, got %v", tt.want, limiter.interval)
 			}
 		})

--- a/internal/niconico/sort.go
+++ b/internal/niconico/sort.go
@@ -1,0 +1,63 @@
+package niconico
+
+import "sort"
+
+const maxUint64Text = "18446744073709551615"
+
+// videoIDSortKey stores the comparable sort text for a video ID.
+type videoIDSortKey struct {
+	length int
+	text   string
+}
+
+// NiconicoSort sorts video IDs by their numeric part in ascending order.
+func NiconicoSort(slice []string) {
+	sort.Slice(slice, func(i, j int) bool {
+		left := videoIDSortKeyFor(slice[i])
+		right := videoIDSortKeyFor(slice[j])
+		if left.length != right.length {
+			return left.length < right.length
+		}
+		if left.text != right.text {
+			return left.text < right.text
+		}
+		return slice[i] < slice[j]
+	})
+}
+
+// videoIDSortKeyFor builds an allocation-free key for sorting a video ID.
+func videoIDSortKeyFor(id string) videoIDSortKey {
+	text := videoIDSortText(id)
+	if normalized, ok := normalizedUint64Text(text); ok {
+		text = normalized
+	}
+	return videoIDSortKey{length: len(text), text: text}
+}
+
+// normalizedUint64Text returns the canonical decimal text when text fits uint64.
+func normalizedUint64Text(text string) (string, bool) {
+	if len(text) == 0 || len(text) > len(maxUint64Text) {
+		return text, false
+	}
+	for i := range text {
+		if text[i] < '0' || text[i] > '9' {
+			return text, false
+		}
+	}
+	if len(text) == len(maxUint64Text) && text > maxUint64Text {
+		return text, false
+	}
+	for len(text) > 1 && text[0] == '0' {
+		text = text[1:]
+	}
+	return text, true
+}
+
+// videoIDSortText returns the comparable text portion of a video ID.
+func videoIDSortText(id string) string {
+	const prefixLen = 2
+	if len(id) >= prefixLen {
+		return id[prefixLen:]
+	}
+	return id
+}

--- a/internal/niconico/sort.go
+++ b/internal/niconico/sort.go
@@ -36,7 +36,7 @@ func videoIDSortKeyFor(id string) videoIDSortKey {
 
 // normalizedUint64Text returns the canonical decimal text when text fits uint64.
 func normalizedUint64Text(text string) (string, bool) {
-	if len(text) == 0 || len(text) > len(maxUint64Text) {
+	if len(text) == 0 {
 		return text, false
 	}
 	for i := range text {
@@ -44,11 +44,14 @@ func normalizedUint64Text(text string) (string, bool) {
 			return text, false
 		}
 	}
-	if len(text) == len(maxUint64Text) && text > maxUint64Text {
-		return text, false
-	}
 	for len(text) > 1 && text[0] == '0' {
 		text = text[1:]
+	}
+	if len(text) > len(maxUint64Text) {
+		return text, false
+	}
+	if len(text) == len(maxUint64Text) && text > maxUint64Text {
+		return text, false
 	}
 	return text, true
 }

--- a/internal/niconico/sort_test.go
+++ b/internal/niconico/sort_test.go
@@ -32,6 +32,11 @@ func TestNiconicoSort(t *testing.T) {
 			input:    []string{"sm100000000", "xx200000000a", "sm99999999"},
 			expected: []string{"sm99999999", "sm100000000", "xx200000000a"},
 		},
+		{
+			name:     "paddedNumericIDsLongerThanUint64Text",
+			input:    []string{"sm2", "sm0000000000000000000000000000000000000001"},
+			expected: []string{"sm0000000000000000000000000000000000000001", "sm2"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/niconico/sort_test.go
+++ b/internal/niconico/sort_test.go
@@ -1,0 +1,72 @@
+package niconico
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestNiconicoSort(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "simple",
+			input:    []string{"sm12", "sm3", "sm1"},
+			expected: []string{"sm1", "sm3", "sm12"},
+		},
+		{
+			name:     "shortString",
+			input:    []string{"sm12", "s", "sm3"},
+			expected: []string{"sm3", "s", "sm12"},
+		},
+		{
+			name:     "longNumericIDs",
+			input:    []string{"sm100000000", "sm99999999", "sm3"},
+			expected: []string{"sm3", "sm99999999", "sm100000000"},
+		},
+		{
+			name:     "malformedWithLongNumericIDs",
+			input:    []string{"sm100000000", "xx200000000a", "sm99999999"},
+			expected: []string{"sm99999999", "sm100000000", "xx200000000a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			slice := append([]string(nil), tt.input...)
+			NiconicoSort(slice)
+			if !reflect.DeepEqual(slice, tt.expected) {
+				t.Errorf("%s: expected %v, got %v", tt.name, tt.expected, slice)
+			}
+		})
+	}
+}
+
+func TestNiconicoSortLargeMixedAllocationBudget(t *testing.T) {
+	base := make([]string, 2000)
+	for i := range base {
+		switch i % 4 {
+		case 0:
+			base[i] = fmt.Sprintf("sm%d", 2000-i)
+		case 1:
+			base[i] = fmt.Sprintf("sm%012d", i)
+		case 2:
+			base[i] = fmt.Sprintf("xx%d", 4000-i)
+		default:
+			base[i] = fmt.Sprintf("sm%dextra", i)
+		}
+	}
+
+	allocs := testing.AllocsPerRun(20, func() {
+		values := append([]string(nil), base...)
+		NiconicoSort(values)
+	})
+
+	const allocationBudget = 25
+	if allocs > allocationBudget {
+		t.Fatalf("allocation budget exceeded: got %.0f allocs, want <= %d", allocs, allocationBudget)
+	}
+}


### PR DESCRIPTION
## Summary

Reduce hot-path allocations and line-output write amplification for large go-nico-list runs.

## What / Why

- Move `NiconicoSort` into a focused file and avoid allocation-heavy `strconv.ParseUint` error paths during mixed ID sorting.
- Avoid allocation-heavy numeric parsing in JSON target sorting.
- Stream line output through a buffered writer instead of building one joined string or issuing multiple writes per item.
- Add allocation/write-count tests and benchmarks for the optimized paths.

## Related issues

Closes #261

## Testing

```bash
go test ./...
go test -race ./...
go vet ./...
golangci-lint run ./...
go mod tidy && go generate ./... && git diff --exit-code -- go.mod go.sum THIRD_PARTY_NOTICES.md
git diff --check --cached
```

Manual QA:

- tmux CLI line output against a valid niconico user URL; stdout contained only the video ID and stderr contained logs/summary.
- tmux CLI JSON output against a valid niconico user URL; stdout parsed with `python3 -m json.tool` and stderr contained logs/summary.

## Fix log

- 2026-06-12: Add RED/GREEN allocation tests for sort and JSON target sorting, optimize numeric comparisons, and add benchmark coverage.
- 2026-06-12: Add RED/GREEN write-count coverage for line output and buffer stdout writes.
- 2026-06-12: Run final verification and ultrawork reviewer; reviewer approved with no blockers.
- 2026-06-13: Address review feedback by normalizing leading-zero padded numeric IDs before uint64 length checks.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [x] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
