### PR TITLE
ci: migrate dependency updates to renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "schedule:daily"
+  ],
+  "enabledManagers": [
+    "gomod",
+    "github-actions"
+  ],
+  "timezone": "Asia/Tokyo",
+  "prConcurrentLimit": 10,
+  "packageRules": [
+    {
+      "description": "Keep Go module artifacts tidy before opening dependency PRs.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "postUpdateOptions": [
+        "gomodTidy"
+      ]
+    },
+    {
+      "description": "Keep indirect Go module updates in scope.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "indirect"
+      ],
+      "enabled": true
+    }
+  ]
+}

--- a/.github/workflows/renovate-generated-files.yml
+++ b/.github/workflows/renovate-generated-files.yml
@@ -1,4 +1,4 @@
-name: Dependabot generated files
+name: Renovate generated files
 
 permissions:
   actions: write
@@ -16,11 +16,13 @@ on:
 jobs:
   refresh-generated-files:
     if: >-
-      github.actor == 'dependabot[bot]' &&
+      github.actor == 'renovate[bot]' &&
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'renovate/') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Dependabot branch
+      - name: Checkout Renovate branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,8 @@ The script uses `go-licenses` (pinned in the script) and excludes test-only depe
 Set `GO_LICENSES_SAVE_PATH` when you also want to save license texts to a directory.
 Requires bash and network access.
 
-Same-repository Dependabot module update PRs automatically refresh generated files with the
-`Dependabot generated files` workflow before the required CI drift checks run.
+Same-repository Renovate module update PRs automatically refresh generated files with the
+`Renovate generated files` workflow before the required CI drift checks run.
 
 ## Project structure
 


### PR DESCRIPTION
## Summary

Migrate Go module and GitHub Actions dependency update automation from Dependabot to Renovate.

## What / Why

- Replace `.github/dependabot.yml` with `.github/renovate.json` scoped to Go modules and GitHub Actions.
- Preserve the daily update cadence and 10 concurrent PR limit.
- Keep direct and indirect Go module updates in scope, and run `gomodTidy` for Renovate updates.
- Include pinned GitHub Actions workflow dependencies in Renovate updates.
- Replace the generated-file refresh workflow with a Renovate-targeted workflow guarded to same-repository `renovate[bot]` PRs from `renovate/` branches.
- Update contributor guidance from Dependabot wording to Renovate wording.

## Related issues

N/A

## Testing

```bash
npx --yes --package renovate renovate-config-validator --strict .github/renovate.json
go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/renovate-generated-files.yml
RENOVATE_CONFIG_FILE=.github/renovate.json npx --yes --package renovate renovate --platform=local --onboarding=false --require-config=ignored --print-config
go mod tidy
go generate ./...
git diff --exit-code -- go.mod go.sum THIRD_PARTY_NOTICES.md
bash scripts/gen-third-party-notices.sh
git diff --exit-code -- THIRD_PARTY_NOTICES.md
go vet ./...
golangci-lint run ./...
go test -count=1 ./...
go test -race -count=1 ./...
git diff --check
```

## Fix log

- 2026-06-14: migrate dependency automation to Renovate, preserve generated-file refresh, validate Renovate config and workflow.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [x] Updated `THIRD_PARTY_NOTICES.md` if dependencies changed
