### PR TITLE
feat: add page concurrency parallel fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Notes:
 - When a safety cap is hit, fetching stops early and returns best-effort results without error.
 - Responses with HTTP status other than 200/404 after retries are treated as fetch errors.
 - HTTP 200 responses with `meta.status != 200` are logged as warnings but still processed.
-- Rate limiting applies globally to all requests (including retries). HTTP 429 `Retry-After` is honored when present.
+- `--page-concurrency` controls concurrent page requests inside each input target. The maximum in-flight request count is roughly `--concurrency * --page-concurrency`.
+- Rate limiting applies globally to all requests (including retries). HTTP 429 `Retry-After` is honored when present. Use `--rate-limit` or `--min-interval` with high concurrency to reduce API load.
 - Progress is auto-disabled when stderr is not a TTY. Use `--progress` to force-enable or `--no-progress` to disable (takes precedence).
 - A run summary is printed to stderr after processing (even when the exit code is non-zero).
 - `--strict` makes invalid inputs return a non-zero exit code while still outputting valid results.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ cat users.txt | go-nico-list --stdin
 | `-t, --tab` | id tab separated flag | `false` |
 | `-u, --url` | output id add url | `false` |
 | `-n, --concurrency` | number of concurrent requests | `3` |
+| `--page-concurrency` | number of concurrent page requests per target | `1` |
 | `--rate-limit` | maximum requests per second (0 disables) | `0` |
 | `--min-interval` | minimum interval between requests | `0s` |
 | `--max-pages` | maximum number of pages to fetch | `0` |
@@ -77,7 +78,7 @@ Notes:
 - Input lines from `--input-file` and `--stdin` are limited to 1 MiB per line; longer lines fail with an input read error.
 - Each input must contain `nicovideo.jp/user/<id>` or `nicovideo.jp/mylist/<id>` (scheme optional). Plain digits or paths without the domain are treated as invalid inputs and skipped.
 - Results are written to stdout; progress and logs are written to stderr. Use `--logfile` to redirect logs to a file.
-- Setting `concurrency` or `retries` to a value less than 1, or `timeout` to a value less than or equal to 0, will cause a runtime error.
+- Setting `concurrency`, `page-concurrency`, or `retries` to a value less than 1, or `timeout` to a value less than or equal to 0, will cause a runtime error.
 - `--dateafter` must be on or before `--datebefore`; inverted ranges return a validation error.
 - `--max-pages` and `--max-videos` are safety caps; `0` disables them.
 - When a safety cap is hit, fetching stops early and returns best-effort results without error.

--- a/cmd/root_config.go
+++ b/cmd/root_config.go
@@ -18,6 +18,7 @@ type RootConfig struct {
 	Tab               bool
 	URL               bool
 	Concurrency       int
+	PageConcurrency   int
 	Retries           int
 	HTTPClientTimeout time.Duration
 	InputFilePath     string
@@ -55,6 +56,7 @@ func DefaultConfig() RootConfig {
 		DateAfter:         "10000101",
 		DateBefore:        "99991231",
 		Concurrency:       3,
+		PageConcurrency:   1,
 		Retries:           defaultRetries,
 		HTTPClientTimeout: defaultHTTPTimeout,
 		BaseURL:           defaultBaseURL,
@@ -104,6 +106,7 @@ func NewRootCommand(cfg RootConfig, deps RootDeps) *cobra.Command {
 	cmd.Flags().BoolVarP(&cfg.Tab, "tab", "t", cfg.Tab, "id tab Separated flag")
 	cmd.Flags().BoolVarP(&cfg.URL, "url", "u", cfg.URL, "output id add url")
 	cmd.Flags().IntVarP(&cfg.Concurrency, "concurrency", "n", cfg.Concurrency, "number of concurrent requests")
+	cmd.Flags().IntVar(&cfg.PageConcurrency, "page-concurrency", cfg.PageConcurrency, "number of concurrent page requests per target")
 	cmd.Flags().DurationVar(&cfg.HTTPClientTimeout, "timeout", cfg.HTTPClientTimeout, "HTTP client timeout")
 	cmd.Flags().IntVar(&cfg.Retries, "retries", cfg.Retries, "number of retries for requests")
 	cmd.Flags().Float64Var(&cfg.RateLimit, "rate-limit", cfg.RateLimit, "maximum requests per second (0 disables)")
@@ -136,6 +139,9 @@ func normalizeRootConfig(cfg RootConfig) RootConfig {
 	}
 	if cfg.Concurrency == 0 {
 		cfg.Concurrency = defaults.Concurrency
+	}
+	if cfg.PageConcurrency == 0 {
+		cfg.PageConcurrency = defaults.PageConcurrency
 	}
 	if cfg.Retries == 0 {
 		cfg.Retries = defaults.Retries

--- a/cmd/root_output_page_concurrency_test.go
+++ b/cmd/root_output_page_concurrency_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRunRootCmdPageConcurrencyFetchesUserPagesBeforeSorting(t *testing.T) {
+	page3Started := make(chan struct{})
+	var page3StartedOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm3","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			select {
+			case <-page3Started:
+				_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}`)
+			case <-r.Context().Done():
+				return
+			}
+		case "3":
+			page3StartedOnce.Do(func() { close(page3Started) })
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-12T00:00:00Z","count":{"comment":10}}}]}}`)
+		default:
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[]}}`)
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { page3StartedOnce.Do(func() { close(page3Started) }) })
+	cfg := testFetchConfig(server.URL)
+	cfg.PageConcurrency = 2
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(cancel)
+	cmd, out, _ := newTestRootCommand(t, cfg, newTestRootDeps())
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"nicovideo.jp/user/1"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := out.String(); got != "sm1\nsm2\nsm3\n" {
+		t.Fatalf("unexpected stdout output: %q", got)
+	}
+}
+
+func TestRunRootCmdPageConcurrencyFetchesMylistPages(t *testing.T) {
+	page3Started := make(chan struct{})
+	var page3StartedOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[{"video":{"id":"sm3","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}}`)
+		case "2":
+			select {
+			case <-page3Started:
+				_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[{"video":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}}`)
+			case <-r.Context().Done():
+				return
+			}
+		case "3":
+			page3StartedOnce.Do(func() { close(page3Started) })
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[{"video":{"id":"sm1","registeredAt":"2024-01-12T00:00:00Z","count":{"comment":10}}}]}}}`)
+		default:
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[]}}}`)
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { page3StartedOnce.Do(func() { close(page3Started) }) })
+	cfg := testFetchConfig(server.URL)
+	cfg.PageConcurrency = 2
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(cancel)
+	cmd, out, _ := newTestRootCommand(t, cfg, newTestRootDeps())
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"nicovideo.jp/mylist/847130"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := out.String(); got != "sm1\nsm2\nsm3\n" {
+		t.Fatalf("unexpected stdout output: %q", got)
+	}
+}

--- a/cmd/root_output_test.go
+++ b/cmd/root_output_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 )
 
 func TestWriteLineOutputMatchesExistingFormatting(t *testing.T) {
@@ -187,76 +186,6 @@ func TestRunRootCmdDefaultSortsFetchedIDs(t *testing.T) {
 	}
 	if got := out.String(); got != "sm1\nsm2\n" {
 		t.Errorf("unexpected stdout output: %q", got)
-	}
-}
-
-func TestRunRootCmdPageConcurrencyFetchesUserPagesBeforeSorting(t *testing.T) {
-	page3Started := make(chan struct{})
-	var page3StartedOnce sync.Once
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Query().Get("page") {
-		case "1":
-			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm3","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
-		case "2":
-			select {
-			case <-page3Started:
-				_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}`)
-			case <-time.After(200 * time.Millisecond):
-				http.Error(w, "page 3 was not fetched concurrently", http.StatusConflict)
-			}
-		case "3":
-			page3StartedOnce.Do(func() { close(page3Started) })
-			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-12T00:00:00Z","count":{"comment":10}}}]}}`)
-		default:
-			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[]}}`)
-		}
-	}))
-	t.Cleanup(server.Close)
-	cfg := testFetchConfig(server.URL)
-	cfg.PageConcurrency = 2
-
-	out, _, err := executeTestRootCommand(t, cfg, newTestRootDeps(), "nicovideo.jp/user/1")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got := out.String(); got != "sm1\nsm2\nsm3\n" {
-		t.Fatalf("unexpected stdout output: %q", got)
-	}
-}
-
-func TestRunRootCmdPageConcurrencyFetchesMylistPages(t *testing.T) {
-	page3Started := make(chan struct{})
-	var page3StartedOnce sync.Once
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Query().Get("page") {
-		case "1":
-			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[{"video":{"id":"sm3","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}}`)
-		case "2":
-			select {
-			case <-page3Started:
-				_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[{"video":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}}`)
-			case <-time.After(200 * time.Millisecond):
-				http.Error(w, "page 3 was not fetched concurrently", http.StatusConflict)
-			}
-		case "3":
-			page3StartedOnce.Do(func() { close(page3Started) })
-			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[{"video":{"id":"sm1","registeredAt":"2024-01-12T00:00:00Z","count":{"comment":10}}}]}}}`)
-		default:
-			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[]}}}`)
-		}
-	}))
-	t.Cleanup(server.Close)
-	cfg := testFetchConfig(server.URL)
-	cfg.PageConcurrency = 2
-
-	out, _, err := executeTestRootCommand(t, cfg, newTestRootDeps(), "nicovideo.jp/mylist/847130")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got := out.String(); got != "sm1\nsm2\nsm3\n" {
-		t.Fatalf("unexpected stdout output: %q", got)
 	}
 }
 

--- a/cmd/root_output_test.go
+++ b/cmd/root_output_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestWriteLineOutputMatchesExistingFormatting(t *testing.T) {
@@ -186,6 +187,76 @@ func TestRunRootCmdDefaultSortsFetchedIDs(t *testing.T) {
 	}
 	if got := out.String(); got != "sm1\nsm2\n" {
 		t.Errorf("unexpected stdout output: %q", got)
+	}
+}
+
+func TestRunRootCmdPageConcurrencyFetchesUserPagesBeforeSorting(t *testing.T) {
+	page3Started := make(chan struct{})
+	var page3StartedOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm3","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			select {
+			case <-page3Started:
+				_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}`)
+			case <-time.After(200 * time.Millisecond):
+				http.Error(w, "page 3 was not fetched concurrently", http.StatusConflict)
+			}
+		case "3":
+			page3StartedOnce.Do(func() { close(page3Started) })
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-12T00:00:00Z","count":{"comment":10}}}]}}`)
+		default:
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[]}}`)
+		}
+	}))
+	t.Cleanup(server.Close)
+	cfg := testFetchConfig(server.URL)
+	cfg.PageConcurrency = 2
+
+	out, _, err := executeTestRootCommand(t, cfg, newTestRootDeps(), "nicovideo.jp/user/1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := out.String(); got != "sm1\nsm2\nsm3\n" {
+		t.Fatalf("unexpected stdout output: %q", got)
+	}
+}
+
+func TestRunRootCmdPageConcurrencyFetchesMylistPages(t *testing.T) {
+	page3Started := make(chan struct{})
+	var page3StartedOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[{"video":{"id":"sm3","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}}`)
+		case "2":
+			select {
+			case <-page3Started:
+				_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[{"video":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}}`)
+			case <-time.After(200 * time.Millisecond):
+				http.Error(w, "page 3 was not fetched concurrently", http.StatusConflict)
+			}
+		case "3":
+			page3StartedOnce.Do(func() { close(page3Started) })
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[{"video":{"id":"sm1","registeredAt":"2024-01-12T00:00:00Z","count":{"comment":10}}}]}}}`)
+		default:
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[]}}}`)
+		}
+	}))
+	t.Cleanup(server.Close)
+	cfg := testFetchConfig(server.URL)
+	cfg.PageConcurrency = 2
+
+	out, _, err := executeTestRootCommand(t, cfg, newTestRootDeps(), "nicovideo.jp/mylist/847130")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := out.String(); got != "sm1\nsm2\nsm3\n" {
+		t.Fatalf("unexpected stdout output: %q", got)
 	}
 }
 

--- a/cmd/root_run.go
+++ b/cmd/root_run.go
@@ -5,90 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"log/slog"
-	"os"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/sh4869221b/go-nico-list/internal/niconico"
 	"github.com/spf13/cobra"
 )
 
 const tabOutputPrefix = "\t\t\t\t\t\t\t\t\t"
-
-func validateFlagsFor(cfg *RootConfig) error {
-	if cfg.Concurrency < 1 {
-		return errors.New("concurrency must be at least 1")
-	}
-	if cfg.Retries < 1 {
-		return errors.New("retries must be at least 1")
-	}
-	if cfg.HTTPClientTimeout <= 0 {
-		return errors.New("timeout must be greater than 0")
-	}
-	if cfg.RateLimit < 0 {
-		return errors.New("rate-limit must be at least 0")
-	}
-	if cfg.MinInterval < 0 {
-		return errors.New("min-interval must be at least 0")
-	}
-	if cfg.MaxPages < 0 {
-		return errors.New("max-pages must be at least 0")
-	}
-	if cfg.MaxVideos < 0 {
-		return errors.New("max-videos must be at least 0")
-	}
-	return nil
-}
-
-// parseDateRange parses date strings into UTC time values.
-func parseDateRange(after, before string) (time.Time, time.Time, error) {
-	const dateFormat = "20060102"
-	parsedAfter, err := time.Parse(dateFormat, after)
-	if err != nil {
-		return time.Time{}, time.Time{}, errors.New("dateafter format error")
-	}
-	parsedBefore, err := time.Parse(dateFormat, before)
-	if err != nil {
-		return time.Time{}, time.Time{}, errors.New("datebefore format error")
-	}
-	if parsedAfter.After(parsedBefore) {
-		return time.Time{}, time.Time{}, errors.New("dateafter must be on or before datebefore")
-	}
-	return parsedAfter, parsedBefore, nil
-}
-
-func setupLoggerFor(path string, deps RootDeps) (*slog.Logger, func() error, error) {
-	deps = normalizeRootDeps(deps)
-	if path == "" {
-		return deps.Logger, func() error { return nil }, nil
-	}
-	logFile, err := deps.OpenLogFile(path)
-	if err != nil {
-		return nil, func() error { return nil }, err
-	}
-	cleanup := func() error { return logFile.Close() }
-	logger := slog.New(slog.NewJSONHandler(logFile, &slog.HandlerOptions{}))
-	return logger, cleanup, nil
-}
-
-// errWriterFor returns the stderr writer for a command.
-func errWriterFor(cmd *cobra.Command) io.Writer {
-	if cmd == nil {
-		return os.Stderr
-	}
-	return cmd.ErrOrStderr()
-}
-
-// outWriterFor returns the stdout writer for a command.
-func outWriterFor(cmd *cobra.Command) io.Writer {
-	if cmd == nil {
-		return os.Stdout
-	}
-	return cmd.OutOrStdout()
-}
 
 func runRootCmdWithConfig(cmd *cobra.Command, args []string, cfg *RootConfig, deps RootDeps) (retErr error) {
 	if err := validateFlagsFor(cfg); err != nil {

--- a/cmd/root_run.go
+++ b/cmd/root_run.go
@@ -136,9 +136,9 @@ func runRootCmdWithConfig(cmd *cobra.Command, args []string, cfg *RootConfig, de
 			var err error
 			switch target.Type {
 			case targetTypeUser:
-				newList, err = niconico.GetVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, runLogger)
+				newList, err = niconico.GetVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, cfg.PageConcurrency, runLogger)
 			case targetTypeMylist:
-				newList, err = niconico.GetMylistVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, runLogger)
+				newList, err = niconico.GetMylistVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, cfg.PageConcurrency, runLogger)
 			}
 			if err != nil {
 				atomic.AddInt64(&fetchErrCount, 1)

--- a/cmd/root_runtime.go
+++ b/cmd/root_runtime.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func validateFlagsFor(cfg *RootConfig) error {
+	if cfg.Concurrency < 1 {
+		return errors.New("concurrency must be at least 1")
+	}
+	if cfg.PageConcurrency < 1 {
+		return errors.New("page-concurrency must be at least 1")
+	}
+	if cfg.Retries < 1 {
+		return errors.New("retries must be at least 1")
+	}
+	if cfg.HTTPClientTimeout <= 0 {
+		return errors.New("timeout must be greater than 0")
+	}
+	if cfg.RateLimit < 0 {
+		return errors.New("rate-limit must be at least 0")
+	}
+	if cfg.MinInterval < 0 {
+		return errors.New("min-interval must be at least 0")
+	}
+	if cfg.MaxPages < 0 {
+		return errors.New("max-pages must be at least 0")
+	}
+	if cfg.MaxVideos < 0 {
+		return errors.New("max-videos must be at least 0")
+	}
+	return nil
+}
+
+// parseDateRange parses date strings into UTC time values.
+func parseDateRange(after, before string) (time.Time, time.Time, error) {
+	const dateFormat = "20060102"
+	parsedAfter, err := time.Parse(dateFormat, after)
+	if err != nil {
+		return time.Time{}, time.Time{}, errors.New("dateafter format error")
+	}
+	parsedBefore, err := time.Parse(dateFormat, before)
+	if err != nil {
+		return time.Time{}, time.Time{}, errors.New("datebefore format error")
+	}
+	if parsedAfter.After(parsedBefore) {
+		return time.Time{}, time.Time{}, errors.New("dateafter must be on or before datebefore")
+	}
+	return parsedAfter, parsedBefore, nil
+}
+
+func setupLoggerFor(path string, deps RootDeps) (*slog.Logger, func() error, error) {
+	deps = normalizeRootDeps(deps)
+	if path == "" {
+		return deps.Logger, func() error { return nil }, nil
+	}
+	logFile, err := deps.OpenLogFile(path)
+	if err != nil {
+		return nil, func() error { return nil }, err
+	}
+	cleanup := func() error { return logFile.Close() }
+	logger := slog.New(slog.NewJSONHandler(logFile, &slog.HandlerOptions{}))
+	return logger, cleanup, nil
+}
+
+// errWriterFor returns the stderr writer for a command.
+func errWriterFor(cmd *cobra.Command) io.Writer {
+	if cmd == nil {
+		return os.Stderr
+	}
+	return cmd.ErrOrStderr()
+}
+
+// outWriterFor returns the stdout writer for a command.
+func outWriterFor(cmd *cobra.Command) io.Writer {
+	if cmd == nil {
+		return os.Stdout
+	}
+	return cmd.OutOrStdout()
+}

--- a/cmd/root_validation_test.go
+++ b/cmd/root_validation_test.go
@@ -104,3 +104,24 @@ func TestConcurrencyValidation(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestPageConcurrencyValidation(t *testing.T) {
+	_, _, err := executeTestRootCommand(t, newTestRootConfig(), newTestRootDeps(), "--page-concurrency=0", "12345")
+	if err == nil || err.Error() != "page-concurrency must be at least 1" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPageConcurrencyFlagDocumentsPerTargetScope(t *testing.T) {
+	cmd, _, _ := newTestRootCommand(t, newTestRootConfig(), newTestRootDeps())
+	flag := cmd.Flags().Lookup("page-concurrency")
+	if flag == nil {
+		t.Fatalf("expected page-concurrency flag")
+	}
+	if flag.DefValue != "1" {
+		t.Fatalf("expected default 1, got %q", flag.DefValue)
+	}
+	if got := flag.Usage; got != "number of concurrent page requests per target" {
+		t.Fatalf("unexpected usage: %q", got)
+	}
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -65,6 +65,7 @@ main.go
     - `dateafter` must be on or before `datebefore`.
   - `--tab` (default `false`), `--url` (default `false`): output formatting.
   - `--concurrency` (default `3`): concurrent requests.
+  - `--page-concurrency` (default `1`): concurrent page requests per target.
   - `--rate-limit` (default `0`): maximum requests per second (float; `0` disables).
   - `--min-interval` (default `0s`): minimum interval between requests (`0` disables).
   - `--max-pages` (default `0`): maximum number of pages to fetch (`0` disables).

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -65,7 +65,7 @@ main.go
     - `dateafter` must be on or before `datebefore`.
   - `--tab` (default `false`), `--url` (default `false`): output formatting.
   - `--concurrency` (default `3`): concurrent requests.
-  - `--page-concurrency` (default `1`): concurrent page requests per target.
+  - `--page-concurrency` (default `1`): concurrent page requests per target; total in-flight requests are roughly `--concurrency * --page-concurrency`.
   - `--rate-limit` (default `0`): maximum requests per second (float; `0` disables).
   - `--min-interval` (default `0s`): minimum interval between requests (`0` disables).
   - `--max-pages` (default `0`): maximum number of pages to fetch (`0` disables).
@@ -138,6 +138,8 @@ main.go
   - `X-Frontend-Id: 6`
   - `Accept: */*`
 - Pagination: fetch until API page end.
+- When `totalCount` is present, page 1 determines the bounded page range and later pages may be fetched concurrently up to `--page-concurrency`.
+- If `totalCount` is unavailable or `--max-videos` is set, fetching uses the sequential empty/404 termination path for compatibility.
 - `max-pages` stops after the given number of pages (best-effort, no error).
 - `max-videos` stops after collecting the given number of filtered IDs (best-effort, no error).
 - Filters:

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -53,6 +53,7 @@ cat users.txt | go-nico-list --stdin
 | `-t, --tab` | id tab separated flag | `false` |
 | `-u, --url` | output id add url | `false` |
 | `-n, --concurrency` | number of concurrent requests | `3` |
+| `--page-concurrency` | number of concurrent page requests per target | `1` |
 | `--rate-limit` | maximum requests per second (0 disables) | `0` |
 | `--min-interval` | minimum interval between requests | `0s` |
 | `--max-pages` | maximum number of pages to fetch | `0` |
@@ -74,12 +75,13 @@ Notes:
 - 入力は引数、`--input-file`、`--stdin` で指定できます（改行区切り）。
 - 各入力は `nicovideo.jp/user/<id>` または `nicovideo.jp/mylist/<id>` を含む必要があります（スキームは任意）。数字のみやドメインなしのパスだけの入力は無効としてスキップされます。
 - 結果は stdout、進捗とログは stderr に出力されます。`--logfile` でログ出力先を変更できます。
-- `concurrency` または `retries` を 1 未満にすると実行時エラーになります。
+- `concurrency`、`page-concurrency`、`retries` を 1 未満にするか、`timeout` を 0 以下にすると実行時エラーになります。
 - `--max-pages` と `--max-videos` は安全制限で、`0` で無効化されます。
 - 上限に達した場合は取得を早期終了し、エラー扱いにせず best-effort の結果を返します。
 - 200/404 以外の HTTP ステータスがリトライ後も続く場合は取得エラー扱いになります。
 - HTTP 200 でも `meta.status != 200` の場合は警告ログを出しつつ処理を続行します。
-- すべてのリクエスト（リトライ含む）に対してレート制限が適用され、HTTP 429 の `Retry-After` は可能な限り尊重されます。
+- `--page-concurrency` は各入力ターゲット内のページ取得並列数を制御します。最大同時リクエスト数の目安は `--concurrency * --page-concurrency` です。
+- すべてのリクエスト（リトライ含む）に対してレート制限が適用され、HTTP 429 の `Retry-After` は可能な限り尊重されます。高い並列数を使う場合は API 負荷を抑えるため `--rate-limit` または `--min-interval` を併用してください。
 - stderr が TTY でない場合は進捗表示を自動で無効化します。`--progress` で強制表示、`--no-progress` で無効化します（優先）。
 - 処理後に実行サマリを stderr に出力します（非0終了時も含む）。
 - `--strict` を指定すると、無効な入力がある場合に非0で終了します（有効な結果は出力されます）。

--- a/internal/niconico/benchmark_test.go
+++ b/internal/niconico/benchmark_test.go
@@ -71,7 +71,7 @@ func BenchmarkGetVideoListLargeUserPayload(b *testing.B) {
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		ids, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+		ids, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 		if err != nil {
 			b.Fatalf("GetVideoList returned error: %v", err)
 		}
@@ -98,7 +98,7 @@ func BenchmarkGetMylistVideoListLargePayload(b *testing.B) {
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		ids, err := GetMylistVideoList(context.Background(), "847130", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+		ids, err := GetMylistVideoList(context.Background(), "847130", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 		if err != nil {
 			b.Fatalf("GetMylistVideoList returned error: %v", err)
 		}

--- a/internal/niconico/client.go
+++ b/internal/niconico/client.go
@@ -30,9 +30,10 @@ func GetVideoList(
 	limiter *RateLimiter,
 	maxPages int,
 	maxVideos int,
+	pageConcurrency int,
 	logger *slog.Logger,
 ) ([]string, error) {
-	return collectVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger,
+	return collectVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, pageConcurrency, logger,
 		func(page int) string {
 			return fmt.Sprintf("%s/users/%s/videos?pageSize=%d&page=%d", baseURL, userID, pageSize, page)
 		},
@@ -53,9 +54,10 @@ func GetMylistVideoList(
 	limiter *RateLimiter,
 	maxPages int,
 	maxVideos int,
+	pageConcurrency int,
 	logger *slog.Logger,
 ) ([]string, error) {
-	return collectVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger,
+	return collectVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, pageConcurrency, logger,
 		func(page int) string {
 			return fmt.Sprintf("%s/mylists/%s?pageSize=%d&page=%d", baseURL, mylistID, pageSize, page)
 		},
@@ -68,15 +70,27 @@ func parseUserVideoPage(body []byte) (parsedPage, error) {
 	if err := json.Unmarshal(body, &nicoData); err != nil {
 		return parsedPage{}, err
 	}
+	var countPayload struct {
+		Data struct {
+			TotalCount *int `json:"totalCount"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &countPayload); err != nil {
+		return parsedPage{}, err
+	}
 	items := make([]videoItem, 0, len(nicoData.Data.Items))
 	for _, s := range nicoData.Data.Items {
 		items = append(items, videoItem{ID: s.Essential.ID, CommentCount: s.Essential.Count.Comment, RegisteredAt: s.Essential.RegisteredAt})
 	}
+	totalCount := 0
+	if countPayload.Data.TotalCount != nil {
+		totalCount = *countPayload.Data.TotalCount
+	}
 	return parsedPage{
 		Items:           items,
 		Status:          nicoData.Meta.Status,
-		TotalCount:      nicoData.Data.TotalCount,
-		TotalCountKnown: true,
+		TotalCount:      totalCount,
+		TotalCountKnown: countPayload.Data.TotalCount != nil,
 	}, nil
 }
 
@@ -86,8 +100,10 @@ func parseMylistPage(body []byte) (parsedPage, error) {
 			Status int `json:"status"`
 		} `json:"meta"`
 		Data struct {
-			Mylist struct {
-				Items []struct {
+			TotalCount *int `json:"totalCount"`
+			Mylist     struct {
+				TotalCount *int `json:"totalCount"`
+				Items      []struct {
 					Video struct {
 						ID           string    `json:"id"`
 						RegisteredAt time.Time `json:"registeredAt"`
@@ -106,7 +122,21 @@ func parseMylistPage(body []byte) (parsedPage, error) {
 	for _, it := range payload.Data.Mylist.Items {
 		items = append(items, videoItem{ID: it.Video.ID, CommentCount: it.Video.Count.Comment, RegisteredAt: it.Video.RegisteredAt})
 	}
-	return parsedPage{Items: items, Status: payload.Meta.Status}, nil
+	totalCount := 0
+	totalCountKnown := false
+	if payload.Data.Mylist.TotalCount != nil {
+		totalCount = *payload.Data.Mylist.TotalCount
+		totalCountKnown = true
+	} else if payload.Data.TotalCount != nil {
+		totalCount = *payload.Data.TotalCount
+		totalCountKnown = true
+	}
+	return parsedPage{
+		Items:           items,
+		Status:          payload.Meta.Status,
+		TotalCount:      totalCount,
+		TotalCountKnown: totalCountKnown,
+	}, nil
 }
 
 func collectVideoList(
@@ -119,6 +149,7 @@ func collectVideoList(
 	limiter *RateLimiter,
 	maxPages int,
 	maxVideos int,
+	pageConcurrency int,
 	logger *slog.Logger,
 	requestURL func(page int) string,
 	parsePage parsePageFunc,
@@ -127,34 +158,37 @@ func collectVideoList(
 		logger = slog.Default()
 	}
 
-	var resStr []string
-
-	for page := 1; ; page++ {
-		if maxPages > 0 && page > maxPages {
-			break
+	firstPage, err := fetchPage(ctx, requestURL(1), httpClientTimeout, retries, limiter, logger, parsePage)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, nil
 		}
-		parsed, err := fetchPage(ctx, requestURL(page), httpClientTimeout, retries, limiter, logger, parsePage)
-		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return nil, nil
-			}
-			return resStr, err
+		return nil, err
+	}
+	if firstPage.NotFound || len(firstPage.Items) == 0 {
+		return nil, nil
+	}
+	resStr := filterItems(firstPage.Items, commentCount, afterDate, beforeDate)
+	if maxVideos > 0 && len(resStr) >= maxVideos {
+		return resStr[:maxVideos], nil
+	}
+	if shouldCollectSequentially(firstPage, pageConcurrency, maxVideos) {
+		return collectRemainingSequentially(ctx, resStr, 2, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger, requestURL, parsePage)
+	}
+	totalPages := pageCountFor(firstPage.TotalCount)
+	if maxPages > 0 && totalPages > maxPages {
+		totalPages = maxPages
+	}
+	if totalPages <= 1 {
+		return resStr, nil
+	}
+	parallelIDs, err := collectPagesParallel(ctx, 2, totalPages, pageConcurrency, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, logger, requestURL, parsePage)
+	resStr = append(resStr, parallelIDs...)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, nil
 		}
-		if parsed.NotFound {
-			break
-		}
-		if parsed.Items == nil {
-			continue
-		}
-		if len(parsed.Items) == 0 {
-			break
-		}
-		for _, id := range filterItems(parsed.Items, commentCount, afterDate, beforeDate) {
-			resStr = append(resStr, id)
-			if maxVideos > 0 && len(resStr) >= maxVideos {
-				return resStr, nil
-			}
-		}
+		return resStr, err
 	}
 	return resStr, nil
 }

--- a/internal/niconico/client.go
+++ b/internal/niconico/client.go
@@ -102,8 +102,9 @@ func parseMylistPage(body []byte) (parsedPage, error) {
 		Data struct {
 			TotalCount *int `json:"totalCount"`
 			Mylist     struct {
-				TotalCount *int `json:"totalCount"`
-				Items      []struct {
+				TotalCount     *int `json:"totalCount"`
+				TotalItemCount *int `json:"totalItemCount"`
+				Items          []struct {
 					Video struct {
 						ID           string    `json:"id"`
 						RegisteredAt time.Time `json:"registeredAt"`
@@ -126,6 +127,9 @@ func parseMylistPage(body []byte) (parsedPage, error) {
 	totalCountKnown := false
 	if payload.Data.Mylist.TotalCount != nil {
 		totalCount = *payload.Data.Mylist.TotalCount
+		totalCountKnown = true
+	} else if payload.Data.Mylist.TotalItemCount != nil {
+		totalCount = *payload.Data.Mylist.TotalItemCount
 		totalCountKnown = true
 	} else if payload.Data.TotalCount != nil {
 		totalCount = *payload.Data.TotalCount

--- a/internal/niconico/client.go
+++ b/internal/niconico/client.go
@@ -5,24 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
-	"net/http"
-	"strconv"
-	"strings"
-	"sync"
 	"time"
 )
 
-const (
-	retryBaseDelay = 100 * time.Millisecond
-	retryMaxDelay  = 30 * time.Second
-)
-
-var (
-	timeNow = time.Now
-	sleepFn = sleepWithContext
-)
+const pageSize = 100
 
 type videoItem struct {
 	ID           string
@@ -47,19 +34,9 @@ func GetVideoList(
 ) ([]string, error) {
 	return collectVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger,
 		func(page int) string {
-			return fmt.Sprintf("%s/users/%s/videos?pageSize=100&page=%d", baseURL, userID, page)
+			return fmt.Sprintf("%s/users/%s/videos?pageSize=%d&page=%d", baseURL, userID, pageSize, page)
 		},
-		func(body []byte) ([]videoItem, int, error) {
-			var nicoData NicoData
-			if err := json.Unmarshal(body, &nicoData); err != nil {
-				return nil, 0, err
-			}
-			items := make([]videoItem, 0, len(nicoData.Data.Items))
-			for _, s := range nicoData.Data.Items {
-				items = append(items, videoItem{ID: s.Essential.ID, CommentCount: s.Essential.Count.Comment, RegisteredAt: s.Essential.RegisteredAt})
-			}
-			return items, nicoData.Meta.Status, nil
-		},
+		parseUserVideoPage,
 	)
 }
 
@@ -80,37 +57,56 @@ func GetMylistVideoList(
 ) ([]string, error) {
 	return collectVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger,
 		func(page int) string {
-			return fmt.Sprintf("%s/mylists/%s?pageSize=100&page=%d", baseURL, mylistID, page)
+			return fmt.Sprintf("%s/mylists/%s?pageSize=%d&page=%d", baseURL, mylistID, pageSize, page)
 		},
-		func(body []byte) ([]videoItem, int, error) {
-			var payload struct {
-				Meta struct {
-					Status int `json:"status"`
-				} `json:"meta"`
-				Data struct {
-					Mylist struct {
-						Items []struct {
-							Video struct {
-								ID           string    `json:"id"`
-								RegisteredAt time.Time `json:"registeredAt"`
-								Count        struct {
-									Comment int `json:"comment"`
-								} `json:"count"`
-							} `json:"video"`
-						} `json:"items"`
-					} `json:"mylist"`
-				} `json:"data"`
-			}
-			if err := json.Unmarshal(body, &payload); err != nil {
-				return nil, 0, err
-			}
-			items := make([]videoItem, 0, len(payload.Data.Mylist.Items))
-			for _, it := range payload.Data.Mylist.Items {
-				items = append(items, videoItem{ID: it.Video.ID, CommentCount: it.Video.Count.Comment, RegisteredAt: it.Video.RegisteredAt})
-			}
-			return items, payload.Meta.Status, nil
-		},
+		parseMylistPage,
 	)
+}
+
+func parseUserVideoPage(body []byte) (parsedPage, error) {
+	var nicoData NicoData
+	if err := json.Unmarshal(body, &nicoData); err != nil {
+		return parsedPage{}, err
+	}
+	items := make([]videoItem, 0, len(nicoData.Data.Items))
+	for _, s := range nicoData.Data.Items {
+		items = append(items, videoItem{ID: s.Essential.ID, CommentCount: s.Essential.Count.Comment, RegisteredAt: s.Essential.RegisteredAt})
+	}
+	return parsedPage{
+		Items:           items,
+		Status:          nicoData.Meta.Status,
+		TotalCount:      nicoData.Data.TotalCount,
+		TotalCountKnown: true,
+	}, nil
+}
+
+func parseMylistPage(body []byte) (parsedPage, error) {
+	var payload struct {
+		Meta struct {
+			Status int `json:"status"`
+		} `json:"meta"`
+		Data struct {
+			Mylist struct {
+				Items []struct {
+					Video struct {
+						ID           string    `json:"id"`
+						RegisteredAt time.Time `json:"registeredAt"`
+						Count        struct {
+							Comment int `json:"comment"`
+						} `json:"count"`
+					} `json:"video"`
+				} `json:"items"`
+			} `json:"mylist"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return parsedPage{}, err
+	}
+	items := make([]videoItem, 0, len(payload.Data.Mylist.Items))
+	for _, it := range payload.Data.Mylist.Items {
+		items = append(items, videoItem{ID: it.Video.ID, CommentCount: it.Video.Count.Comment, RegisteredAt: it.Video.RegisteredAt})
+	}
+	return parsedPage{Items: items, Status: payload.Meta.Status}, nil
 }
 
 func collectVideoList(
@@ -125,7 +121,7 @@ func collectVideoList(
 	maxVideos int,
 	logger *slog.Logger,
 	requestURL func(page int) string,
-	parseItems func(body []byte) ([]videoItem, int, error),
+	parsePage parsePageFunc,
 ) ([]string, error) {
 	if logger == nil {
 		logger = slog.Default()
@@ -137,219 +133,28 @@ func collectVideoList(
 		if maxPages > 0 && page > maxPages {
 			break
 		}
-		res, err := retriesRequest(ctx, requestURL(page), httpClientTimeout, retries, limiter)
+		parsed, err := fetchPage(ctx, requestURL(page), httpClientTimeout, retries, limiter, logger, parsePage)
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return nil, nil
 			}
 			return resStr, err
 		}
-		if res == nil {
+		if parsed.NotFound {
+			break
+		}
+		if parsed.Items == nil {
 			continue
 		}
-		if closeAndIsNotFound(res) {
+		if len(parsed.Items) == 0 {
 			break
 		}
-		body, err := io.ReadAll(res.Body)
-		_ = res.Body.Close()
-		if err != nil {
-			logger.Error("failed to read response body", "error", err)
-			return resStr, err
-		}
-		items, status, err := parseItems(body)
-		if err != nil {
-			logger.Error("failed to unmarshal response body", "error", err)
-			return resStr, err
-		}
-		if status != http.StatusOK {
-			logger.Warn("unexpected meta status", "status", status)
-		}
-		if len(items) == 0 {
-			break
-		}
-		for _, item := range items {
-			if item.CommentCount <= commentCount {
-				continue
-			}
-			if item.RegisteredAt.Before(afterDate) {
-				continue
-			}
-			if !item.RegisteredAt.Before(beforeDate.AddDate(0, 0, 1)) {
-				continue
-			}
-			resStr = append(resStr, item.ID)
+		for _, id := range filterItems(parsed.Items, commentCount, afterDate, beforeDate) {
+			resStr = append(resStr, id)
 			if maxVideos > 0 && len(resStr) >= maxVideos {
 				return resStr, nil
 			}
 		}
 	}
 	return resStr, nil
-}
-
-// closeAndIsNotFound closes the response body and reports whether the status is 404.
-func closeAndIsNotFound(res *http.Response) bool {
-	if res == nil || res.StatusCode != http.StatusNotFound {
-		return false
-	}
-	_ = res.Body.Close()
-	return true
-}
-
-// evaluateResponse validates HTTP responses and returns any retry delay needed.
-func evaluateResponse(res *http.Response) (*http.Response, time.Duration, error) {
-	if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusNotFound {
-		return res, 0, nil
-	}
-	retryAfter := retryAfterDelay(res)
-	_ = res.Body.Close()
-	return nil, retryAfter, fmt.Errorf("unexpected status: %d", res.StatusCode)
-}
-
-// nextRetryDelay calculates the next backoff delay, honoring Retry-After when larger.
-func nextRetryDelay(retryAfter time.Duration, attempt int) time.Duration {
-	wait := min(retryBaseDelay*time.Duration(1<<uint(attempt-1)), retryMaxDelay)
-	return max(retryAfter, wait)
-}
-
-// retriesRequest issues a GET request with retries and rate limiting.
-func retriesRequest(ctx context.Context, url string, httpClientTimeout time.Duration, retries int, limiter *RateLimiter) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("X-Frontend-Id", "6")
-	req.Header.Set("Accept", "*/*")
-	client := &http.Client{Timeout: httpClientTimeout}
-
-	var lastErr error
-
-	delay := time.Duration(0)
-	for attempt := 1; attempt <= retries; attempt++ {
-		if err := waitBeforeAttempt(ctx, limiter, delay); err != nil {
-			return nil, err
-		}
-		delay = 0
-
-		res, err := client.Do(req)
-		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				if res != nil {
-					_ = res.Body.Close()
-				}
-				return nil, err
-			}
-			if res != nil {
-				_ = res.Body.Close()
-			}
-			lastErr = err
-		} else {
-			var retryAfter time.Duration
-			res, retryAfter, err = evaluateResponse(res)
-			if err == nil {
-				return res, nil
-			}
-			lastErr = err
-			delay = retryAfter
-		}
-
-		if attempt == retries {
-			return nil, lastErr
-		}
-
-		delay = nextRetryDelay(delay, attempt)
-	}
-
-	return nil, lastErr
-}
-
-// sleepWithContext waits for the duration or returns early on context cancellation.
-func sleepWithContext(ctx context.Context, d time.Duration) error {
-	if d <= 0 {
-		return nil
-	}
-	timer := time.NewTimer(d)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
-}
-
-// waitBeforeAttempt applies any delay and rate limiting before a request attempt.
-func waitBeforeAttempt(ctx context.Context, limiter *RateLimiter, delay time.Duration) error {
-	if limiter == nil {
-		return sleepFn(ctx, delay)
-	}
-	return limiter.Wait(ctx, delay)
-}
-
-// retryAfterDelay parses Retry-After for 429 responses and returns a delay.
-func retryAfterDelay(res *http.Response) time.Duration {
-	if res == nil || res.StatusCode != http.StatusTooManyRequests {
-		return 0
-	}
-	value := strings.TrimSpace(res.Header.Get("Retry-After"))
-	if value == "" {
-		return 0
-	}
-	if seconds, err := strconv.Atoi(value); err == nil {
-		if seconds <= 0 {
-			return 0
-		}
-		return time.Duration(seconds) * time.Second
-	}
-	if parsed, err := http.ParseTime(value); err == nil {
-		if delay := parsed.Sub(timeNow()); delay > 0 {
-			return delay
-		}
-	}
-	return 0
-}
-
-// RateLimiter enforces a minimum interval between requests.
-type RateLimiter struct {
-	mu       sync.Mutex
-	interval time.Duration
-	nextTime time.Time
-}
-
-// NewRateLimiter builds a RateLimiter from rate and minimum interval settings.
-func NewRateLimiter(rateLimit float64, minInterval time.Duration) *RateLimiter {
-	interval := time.Duration(0)
-	if rateLimit > 0 {
-		seconds := float64(time.Second) / rateLimit
-		if seconds < float64(time.Nanosecond) {
-			interval = time.Nanosecond
-		} else {
-			interval = time.Duration(seconds)
-		}
-	}
-	if minInterval > interval {
-		interval = minInterval
-	}
-	if interval <= 0 {
-		return nil
-	}
-	return &RateLimiter{interval: interval}
-}
-
-// Wait blocks until the next request slot is available.
-func (l *RateLimiter) Wait(ctx context.Context, minDelay time.Duration) error {
-	if l == nil {
-		return sleepFn(ctx, minDelay)
-	}
-	if minDelay < 0 {
-		minDelay = 0
-	}
-	now := timeNow()
-	readyAt := now.Add(minDelay)
-	l.mu.Lock()
-	if l.nextTime.After(readyAt) {
-		readyAt = l.nextTime
-	}
-	l.nextTime = readyAt.Add(l.interval)
-	l.mu.Unlock()
-	return sleepFn(ctx, readyAt.Sub(now))
 }

--- a/internal/niconico/client_page_concurrency_stop_test.go
+++ b/internal/niconico/client_page_concurrency_stop_test.go
@@ -1,0 +1,151 @@
+package niconico
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestGetVideoListPageConcurrencyIgnoresErrorAfterEmptyPage(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	page3Started := make(chan struct{})
+	var page3StartedOnce sync.Once
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			select {
+			case <-page3Started:
+			case <-r.Context().Done():
+				return
+			}
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+		case "3":
+			page3StartedOnce.Do(func() { close(page3Started) })
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, "invalid")
+		default:
+			t.Errorf("unexpected page request: %s", r.URL.Query().Get("page"))
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+		}
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { page3StartedOnce.Do(func() { close(page3Started) }) })
+
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 2, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"sm1"}) {
+		t.Fatalf("unexpected ids: %v", got)
+	}
+}
+
+func TestGetVideoListPageConcurrencyReturnsEarlierPageBeforeLaterEmptyPage(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	releasePage2 := make(chan struct{})
+	var releasePage2Once sync.Once
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			select {
+			case <-releasePage2:
+			case <-r.Context().Done():
+				return
+			}
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[{"essential":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "3":
+			releasePage2Once.Do(func() { close(releasePage2) })
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+		default:
+			t.Errorf("unexpected page request: %s", r.URL.Query().Get("page"))
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+		}
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { releasePage2Once.Do(func() { close(releasePage2) }) })
+
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 2, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"sm1", "sm2"}) {
+		t.Fatalf("unexpected ids: %v", got)
+	}
+}
+
+func TestGetVideoListPageConcurrencyCancelsToEmptyResult(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	page2Started := make(chan struct{})
+	var page2StartedOnce sync.Once
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			page2StartedOnce.Do(func() { close(page2Started) })
+			<-r.Context().Done()
+		default:
+			select {
+			case <-r.Context().Done():
+			default:
+				_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+			}
+		}
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+	resultCh := make(chan struct {
+		ids []string
+		err error
+	}, 1)
+	go func() {
+		ids, err := GetVideoList(ctx, "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 2, logger)
+		resultCh <- struct {
+			ids []string
+			err error
+		}{ids: ids, err: err}
+	}()
+	select {
+	case <-page2Started:
+	case <-time.After(time.Second):
+		t.Fatal("expected page 2 request to start")
+	}
+	cancel()
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			t.Fatalf("unexpected error: %v", result.err)
+		}
+		if len(result.ids) != 0 {
+			t.Fatalf("expected empty result after cancellation, got %v", result.ids)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected canceled fetch to finish")
+	}
+}

--- a/internal/niconico/client_page_concurrency_test.go
+++ b/internal/niconico/client_page_concurrency_test.go
@@ -1,0 +1,173 @@
+package niconico
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestGetVideoListSequentialNilItemsStopsPagination(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	var requestedPages []string
+	var mu sync.Mutex
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestedPages = append(requestedPages, r.URL.Query().Get("page"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{}}`)
+		default:
+			t.Errorf("unexpected page request: %s", r.URL.Query().Get("page"))
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{}}`)
+		}
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"sm1"}) {
+		t.Fatalf("unexpected ids: %v", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !reflect.DeepEqual(requestedPages, []string{"1", "2"}) {
+		t.Fatalf("unexpected requested pages: %v", requestedPages)
+	}
+}
+
+func TestGetVideoListPageConcurrencyPreservesPageOrder(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	releasePage2 := make(chan struct{})
+	var releaseOnce sync.Once
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			select {
+			case <-releasePage2:
+			case <-r.Context().Done():
+				return
+			}
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[{"essential":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "3":
+			releaseOnce.Do(func() { close(releasePage2) })
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[{"essential":{"id":"sm3","registeredAt":"2024-01-12T00:00:00Z","count":{"comment":10}}}]}}`)
+		default:
+			t.Errorf("unexpected page request: %s", r.URL.Query().Get("page"))
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+		}
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releasePage2) }) })
+
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 2, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"sm1", "sm2", "sm3"}) {
+		t.Fatalf("expected page-order ids, got %v", got)
+	}
+}
+
+func TestGetVideoListPageConcurrencyStopsSchedulingAfterFetchError(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	var requestedPages []string
+	var mu sync.Mutex
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestedPages = append(requestedPages, r.URL.Query().Get("page"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":500,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, "invalid")
+		case "3":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+		default:
+			t.Errorf("unexpected page request after error: %s", r.URL.Query().Get("page"))
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+		}
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 2, logger)
+	if err == nil {
+		t.Fatal("expected fetch error")
+	}
+	if !reflect.DeepEqual(got, []string{"sm1"}) {
+		t.Fatalf("unexpected partial ids: %v", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestedPages) > 3 || requestedPages[0] != "1" || requestedPages[1] != "2" {
+		t.Fatalf("unexpected requested pages: %v", requestedPages)
+	}
+}
+
+func TestGetMylistVideoListPageConcurrencyUsesTotalItemCount(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	var requestedPages []string
+	var mu sync.Mutex
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestedPages = append(requestedPages, r.URL.Query().Get("page"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalItemCount":200,"items":[{"video":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}}`)
+		case "2":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"items":[{"video":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}}`)
+		default:
+			t.Errorf("unexpected page request: %s", r.URL.Query().Get("page"))
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"items":[]}}}`)
+		}
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	got, err := GetMylistVideoList(context.Background(), "847130", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 2, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"sm1", "sm2"}) {
+		t.Fatalf("unexpected ids: %v", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !reflect.DeepEqual(requestedPages, []string{"1", "2"}) {
+		t.Fatalf("unexpected requested pages: %v", requestedPages)
+	}
+}

--- a/internal/niconico/client_page_concurrency_test.go
+++ b/internal/niconico/client_page_concurrency_test.go
@@ -107,7 +107,7 @@ func TestGetVideoListPageConcurrencyStopsSchedulingAfterFetchError(t *testing.T)
 		case "2":
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = io.WriteString(w, "invalid")
-		case "3", "4":
+		case "3":
 			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
 		default:
 			t.Errorf("unexpected page request after error: %s", r.URL.Query().Get("page"))
@@ -129,7 +129,58 @@ func TestGetVideoListPageConcurrencyStopsSchedulingAfterFetchError(t *testing.T)
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	if slices.Contains(requestedPages, "5") {
+	if slices.Contains(requestedPages, "4") {
+		t.Fatalf("unexpected requested pages: %v", requestedPages)
+	}
+}
+
+func TestGetVideoListPageConcurrencyStopsAtEmptyPage(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	releasePage3 := make(chan struct{})
+	var releaseOnce sync.Once
+	var requestedPages []string
+	var mu sync.Mutex
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		mu.Lock()
+		requestedPages = append(requestedPages, page)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch page {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":500,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			releaseOnce.Do(func() { close(releasePage3) })
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+		case "3":
+			select {
+			case <-releasePage3:
+			case <-r.Context().Done():
+				return
+			}
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[{"essential":{"id":"sm3","registeredAt":"2024-01-12T00:00:00Z","count":{"comment":10}}}]}}`)
+		default:
+			t.Errorf("unexpected page request after empty page: %s", page)
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+		}
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releasePage3) }) })
+
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 2, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"sm1"}) {
+		t.Fatalf("unexpected ids: %v", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if slices.Contains(requestedPages, "4") {
 		t.Fatalf("unexpected requested pages: %v", requestedPages)
 	}
 }

--- a/internal/niconico/client_page_concurrency_test.go
+++ b/internal/niconico/client_page_concurrency_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -106,7 +107,7 @@ func TestGetVideoListPageConcurrencyStopsSchedulingAfterFetchError(t *testing.T)
 		case "2":
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = io.WriteString(w, "invalid")
-		case "3":
+		case "3", "4":
 			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
 		default:
 			t.Errorf("unexpected page request after error: %s", r.URL.Query().Get("page"))
@@ -128,7 +129,7 @@ func TestGetVideoListPageConcurrencyStopsSchedulingAfterFetchError(t *testing.T)
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	if len(requestedPages) > 3 || requestedPages[0] != "1" || requestedPages[1] != "2" {
+	if slices.Contains(requestedPages, "5") {
 		t.Fatalf("unexpected requested pages: %v", requestedPages)
 	}
 }

--- a/internal/niconico/client_test.go
+++ b/internal/niconico/client_test.go
@@ -20,6 +20,14 @@ type trackingReadCloser struct {
 	closed bool
 }
 
+func sameStringSet(got []string, want []string) bool {
+	gotCopy := append([]string{}, got...)
+	wantCopy := append([]string{}, want...)
+	slices.Sort(gotCopy)
+	slices.Sort(wantCopy)
+	return slices.Equal(gotCopy, wantCopy)
+}
+
 func (r *trackingReadCloser) Read(_ []byte) (int, error) {
 	return 0, io.EOF
 }
@@ -461,7 +469,7 @@ func TestGetVideoList(t *testing.T) {
 		after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 		before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-		got, err := GetVideoList(context.Background(), "12345", 5, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+		got, err := GetVideoList(context.Background(), "12345", 5, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -487,7 +495,7 @@ func TestGetVideoList(t *testing.T) {
 		after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 		before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-		got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+		got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -508,7 +516,7 @@ func TestGetVideoList(t *testing.T) {
 		after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 		before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-		_, err := GetVideoList(context.Background(), "12345", 5, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+		_, err := GetVideoList(context.Background(), "12345", 5, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -530,7 +538,7 @@ func TestGetVideoListContextCanceled(t *testing.T) {
 	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-	got, err := GetVideoList(ctx, "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+	got, err := GetVideoList(ctx, "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -553,7 +561,7 @@ func TestGetVideoListHandleNotFound(t *testing.T) {
 	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -579,7 +587,7 @@ func TestGetVideoListHandleServerError(t *testing.T) {
 	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-	_, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 2, time.Second, nil, 0, 0, logger)
+	_, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 2, time.Second, nil, 0, 0, 1, logger)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -607,7 +615,7 @@ func TestGetVideoListPartialOnError(t *testing.T) {
 	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -634,7 +642,7 @@ func TestGetVideoListMaxPagesStopsEarly(t *testing.T) {
 	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 1, 0, logger)
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 1, 0, 1, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -643,6 +651,74 @@ func TestGetVideoListMaxPagesStopsEarly(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("expected 1 attempt, got %d", count)
+	}
+}
+
+func TestGetVideoListPageConcurrencyAppliesMaxPagesBeforeScheduling(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	var requestedPages []string
+	var mu sync.Mutex
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestedPages = append(requestedPages, r.URL.Query().Get("page"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}`)
+		default:
+			t.Errorf("unexpected page request: %s", r.URL.Query().Get("page"))
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[]}}`)
+		}
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 2, 0, 2, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sameStringSet(got, []string{"sm1", "sm2"}) {
+		t.Fatalf("unexpected ids: %v", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !reflect.DeepEqual(requestedPages, []string{"1", "2"}) {
+		t.Fatalf("unexpected requested pages: %v", requestedPages)
+	}
+}
+
+func TestGetVideoListPageConcurrencyReturnsPartialIDsOnFetchError(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}`)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, "invalid")
+		}
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 2, logger)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !sameStringSet(got, []string{"sm1", "sm2"}) {
+		t.Fatalf("unexpected partial ids: %v", got)
 	}
 }
 
@@ -660,7 +736,7 @@ func TestGetVideoListMaxVideosStopsEarly(t *testing.T) {
 	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 2, logger)
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 2, 1, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -696,11 +772,7 @@ func TestGetMylistVideoList(t *testing.T) {
 		time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC),
 		server.URL,
 		1,
-		time.Second,
-		nil,
-		0,
-		0,
-		slog.New(slog.DiscardHandler),
+		time.Second, nil, 0, 0, 1, slog.New(slog.DiscardHandler),
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/niconico/collection.go
+++ b/internal/niconico/collection.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -69,6 +70,19 @@ type pageResult struct {
 	terminate bool
 }
 
+func lowerStopBefore(stopBefore *atomic.Int64, page int) {
+	newStop := int64(page)
+	for {
+		current := stopBefore.Load()
+		if newStop >= current {
+			return
+		}
+		if stopBefore.CompareAndSwap(current, newStop) {
+			return
+		}
+	}
+}
+
 func collectPagesParallel(
 	ctx context.Context,
 	startPage int,
@@ -88,32 +102,28 @@ func collectPagesParallel(
 	results := make(chan pageResult, pageConcurrency)
 	stopScheduling := make(chan struct{})
 	var stopOnce sync.Once
+	var stopBefore atomic.Int64
+	stopBefore.Store(int64(endPage + 1))
 	var wg sync.WaitGroup
 	for range pageConcurrency {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for page := range pages {
-				select {
-				case <-stopScheduling:
+				if int64(page) >= stopBefore.Load() {
 					return
-				default:
 				}
 				parsed, err := fetchPage(ctx, requestURL(page), httpClientTimeout, retries, limiter, logger, parsePage)
 				if err != nil {
+					lowerStopBefore(&stopBefore, page)
 					stopOnce.Do(func() { close(stopScheduling) })
-					select {
-					case results <- pageResult{page: page, err: err}:
-					case <-ctx.Done():
-					}
+					results <- pageResult{page: page, err: err}
 					return
 				}
 				if parsed.NotFound || len(parsed.Items) == 0 {
+					lowerStopBefore(&stopBefore, page)
 					stopOnce.Do(func() { close(stopScheduling) })
-					select {
-					case results <- pageResult{page: page, terminate: true}:
-					case <-ctx.Done():
-					}
+					results <- pageResult{page: page, terminate: true}
 					return
 				}
 				select {
@@ -158,21 +168,23 @@ func collectPagesParallel(
 	stopAtPage := endPage + 1
 	for result := range results {
 		if result.err != nil {
-			if firstErr == nil {
-				firstErr = result.err
-			}
 			if result.page < stopAtPage {
 				stopAtPage = result.page
+				firstErr = result.err
 			}
 			continue
 		}
 		if result.terminate {
 			if result.page < stopAtPage {
 				stopAtPage = result.page
+				firstErr = nil
 			}
 			continue
 		}
 		idsByPage[result.page] = result.ids
+	}
+	if firstErr == nil && ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 	var ids []string
 	for page := startPage; page < stopAtPage; page++ {

--- a/internal/niconico/collection.go
+++ b/internal/niconico/collection.go
@@ -1,0 +1,136 @@
+package niconico
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+func collectRemainingSequentially(
+	ctx context.Context,
+	resStr []string,
+	startPage int,
+	commentCount int,
+	afterDate time.Time,
+	beforeDate time.Time,
+	retries int,
+	httpClientTimeout time.Duration,
+	limiter *RateLimiter,
+	maxPages int,
+	maxVideos int,
+	logger *slog.Logger,
+	requestURL func(page int) string,
+	parsePage parsePageFunc,
+) ([]string, error) {
+	for page := startPage; ; page++ {
+		if maxPages > 0 && page > maxPages {
+			break
+		}
+		parsed, err := fetchPage(ctx, requestURL(page), httpClientTimeout, retries, limiter, logger, parsePage)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, nil
+			}
+			return resStr, err
+		}
+		if parsed.NotFound {
+			break
+		}
+		if parsed.Items == nil {
+			continue
+		}
+		if len(parsed.Items) == 0 {
+			break
+		}
+		for _, id := range filterItems(parsed.Items, commentCount, afterDate, beforeDate) {
+			resStr = append(resStr, id)
+			if maxVideos > 0 && len(resStr) >= maxVideos {
+				return resStr, nil
+			}
+		}
+	}
+	return resStr, nil
+}
+
+func shouldCollectSequentially(firstPage parsedPage, pageConcurrency int, maxVideos int) bool {
+	return pageConcurrency <= 1 || maxVideos > 0 || !firstPage.TotalCountKnown
+}
+
+func pageCountFor(totalCount int) int {
+	if totalCount <= 0 {
+		return 0
+	}
+	return (totalCount + pageSize - 1) / pageSize
+}
+
+type pageResult struct {
+	ids []string
+	err error
+}
+
+func collectPagesParallel(
+	ctx context.Context,
+	startPage int,
+	endPage int,
+	pageConcurrency int,
+	commentCount int,
+	afterDate time.Time,
+	beforeDate time.Time,
+	retries int,
+	httpClientTimeout time.Duration,
+	limiter *RateLimiter,
+	logger *slog.Logger,
+	requestURL func(page int) string,
+	parsePage parsePageFunc,
+) ([]string, error) {
+	pages := make(chan int)
+	results := make(chan pageResult, pageConcurrency)
+	var wg sync.WaitGroup
+	for range pageConcurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for page := range pages {
+				parsed, err := fetchPage(ctx, requestURL(page), httpClientTimeout, retries, limiter, logger, parsePage)
+				if err != nil {
+					results <- pageResult{err: err}
+					continue
+				}
+				if parsed.NotFound || len(parsed.Items) == 0 {
+					continue
+				}
+				results <- pageResult{ids: filterItems(parsed.Items, commentCount, afterDate, beforeDate)}
+			}
+		}()
+	}
+	go func() {
+		for page := startPage; page <= endPage; page++ {
+			select {
+			case pages <- page:
+			case <-ctx.Done():
+				close(pages)
+				wg.Wait()
+				close(results)
+				return
+			}
+		}
+		close(pages)
+		wg.Wait()
+		close(results)
+	}()
+
+	var ids []string
+	var firstErr error
+	for result := range results {
+		if result.err != nil {
+			if firstErr == nil {
+				firstErr = result.err
+			}
+			continue
+		}
+		ids = append(ids, result.ids...)
+	}
+	return ids, firstErr
+}

--- a/internal/niconico/collection.go
+++ b/internal/niconico/collection.go
@@ -63,9 +63,10 @@ func pageCountFor(totalCount int) int {
 }
 
 type pageResult struct {
-	page int
-	ids  []string
-	err  error
+	page      int
+	ids       []string
+	err       error
+	terminate bool
 }
 
 func collectPagesParallel(
@@ -93,17 +94,27 @@ func collectPagesParallel(
 		go func() {
 			defer wg.Done()
 			for page := range pages {
+				select {
+				case <-stopScheduling:
+					return
+				default:
+				}
 				parsed, err := fetchPage(ctx, requestURL(page), httpClientTimeout, retries, limiter, logger, parsePage)
 				if err != nil {
+					stopOnce.Do(func() { close(stopScheduling) })
 					select {
 					case results <- pageResult{page: page, err: err}:
 					case <-ctx.Done():
 					}
-					stopOnce.Do(func() { close(stopScheduling) })
 					return
 				}
 				if parsed.NotFound || len(parsed.Items) == 0 {
-					continue
+					stopOnce.Do(func() { close(stopScheduling) })
+					select {
+					case results <- pageResult{page: page, terminate: true}:
+					case <-ctx.Done():
+					}
+					return
 				}
 				select {
 				case results <- pageResult{page: page, ids: filterItems(parsed.Items, commentCount, afterDate, beforeDate)}:
@@ -116,17 +127,25 @@ func collectPagesParallel(
 	go func() {
 		for page := startPage; page <= endPage; page++ {
 			select {
-			case pages <- page:
-			case <-ctx.Done():
-				close(pages)
-				wg.Wait()
-				close(results)
-				return
 			case <-stopScheduling:
 				close(pages)
 				wg.Wait()
 				close(results)
 				return
+			default:
+			}
+			select {
+			case <-stopScheduling:
+				close(pages)
+				wg.Wait()
+				close(results)
+				return
+			case <-ctx.Done():
+				close(pages)
+				wg.Wait()
+				close(results)
+				return
+			case pages <- page:
 			}
 		}
 		close(pages)
@@ -136,17 +155,27 @@ func collectPagesParallel(
 
 	idsByPage := make(map[int][]string)
 	var firstErr error
+	stopAtPage := endPage + 1
 	for result := range results {
 		if result.err != nil {
 			if firstErr == nil {
 				firstErr = result.err
+			}
+			if result.page < stopAtPage {
+				stopAtPage = result.page
+			}
+			continue
+		}
+		if result.terminate {
+			if result.page < stopAtPage {
+				stopAtPage = result.page
 			}
 			continue
 		}
 		idsByPage[result.page] = result.ids
 	}
 	var ids []string
-	for page := startPage; page <= endPage; page++ {
+	for page := startPage; page < stopAtPage; page++ {
 		ids = append(ids, idsByPage[page]...)
 	}
 	return ids, firstErr

--- a/internal/niconico/collection.go
+++ b/internal/niconico/collection.go
@@ -38,9 +38,6 @@ func collectRemainingSequentially(
 		if parsed.NotFound {
 			break
 		}
-		if parsed.Items == nil {
-			continue
-		}
 		if len(parsed.Items) == 0 {
 			break
 		}
@@ -66,8 +63,9 @@ func pageCountFor(totalCount int) int {
 }
 
 type pageResult struct {
-	ids []string
-	err error
+	page int
+	ids  []string
+	err  error
 }
 
 func collectPagesParallel(
@@ -87,6 +85,8 @@ func collectPagesParallel(
 ) ([]string, error) {
 	pages := make(chan int)
 	results := make(chan pageResult, pageConcurrency)
+	stopScheduling := make(chan struct{})
+	var stopOnce sync.Once
 	var wg sync.WaitGroup
 	for range pageConcurrency {
 		wg.Add(1)
@@ -95,13 +95,21 @@ func collectPagesParallel(
 			for page := range pages {
 				parsed, err := fetchPage(ctx, requestURL(page), httpClientTimeout, retries, limiter, logger, parsePage)
 				if err != nil {
-					results <- pageResult{err: err}
-					continue
+					select {
+					case results <- pageResult{page: page, err: err}:
+					case <-ctx.Done():
+					}
+					stopOnce.Do(func() { close(stopScheduling) })
+					return
 				}
 				if parsed.NotFound || len(parsed.Items) == 0 {
 					continue
 				}
-				results <- pageResult{ids: filterItems(parsed.Items, commentCount, afterDate, beforeDate)}
+				select {
+				case results <- pageResult{page: page, ids: filterItems(parsed.Items, commentCount, afterDate, beforeDate)}:
+				case <-ctx.Done():
+					return
+				}
 			}
 		}()
 	}
@@ -114,6 +122,11 @@ func collectPagesParallel(
 				wg.Wait()
 				close(results)
 				return
+			case <-stopScheduling:
+				close(pages)
+				wg.Wait()
+				close(results)
+				return
 			}
 		}
 		close(pages)
@@ -121,7 +134,7 @@ func collectPagesParallel(
 		close(results)
 	}()
 
-	var ids []string
+	idsByPage := make(map[int][]string)
 	var firstErr error
 	for result := range results {
 		if result.err != nil {
@@ -130,7 +143,11 @@ func collectPagesParallel(
 			}
 			continue
 		}
-		ids = append(ids, result.ids...)
+		idsByPage[result.page] = result.ids
+	}
+	var ids []string
+	for page := startPage; page <= endPage; page++ {
+		ids = append(ids, idsByPage[page]...)
 	}
 	return ids, firstErr
 }

--- a/internal/niconico/e2e_test.go
+++ b/internal/niconico/e2e_test.go
@@ -43,6 +43,7 @@ func TestGetVideoListE2E(t *testing.T) {
 		nil,
 		2,
 		10,
+		1,
 		logger,
 	)
 	if err != nil {

--- a/internal/niconico/page_fetch.go
+++ b/internal/niconico/page_fetch.go
@@ -1,0 +1,73 @@
+package niconico
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+type parsedPage struct {
+	Items           []videoItem
+	Status          int
+	TotalCount      int
+	TotalCountKnown bool
+	NotFound        bool
+}
+
+type parsePageFunc func([]byte) (parsedPage, error)
+
+func fetchPage(
+	ctx context.Context,
+	url string,
+	httpClientTimeout time.Duration,
+	retries int,
+	limiter *RateLimiter,
+	logger *slog.Logger,
+	parsePage parsePageFunc,
+) (parsedPage, error) {
+	res, err := retriesRequest(ctx, url, httpClientTimeout, retries, limiter)
+	if err != nil {
+		return parsedPage{}, err
+	}
+	if res == nil {
+		return parsedPage{}, nil
+	}
+	if closeAndIsNotFound(res) {
+		return parsedPage{NotFound: true}, nil
+	}
+	body, err := io.ReadAll(res.Body)
+	_ = res.Body.Close()
+	if err != nil {
+		logger.Error("failed to read response body", "error", err)
+		return parsedPage{}, err
+	}
+	page, err := parsePage(body)
+	if err != nil {
+		logger.Error("failed to unmarshal response body", "error", err)
+		return parsedPage{}, err
+	}
+	if page.Status != http.StatusOK {
+		logger.Warn("unexpected meta status", "status", page.Status)
+	}
+	return page, nil
+}
+
+func filterItems(items []videoItem, commentCount int, afterDate time.Time, beforeDate time.Time) []string {
+	ids := make([]string, 0, len(items))
+	exclusiveBefore := beforeDate.AddDate(0, 0, 1)
+	for _, item := range items {
+		if item.CommentCount <= commentCount {
+			continue
+		}
+		if item.RegisteredAt.Before(afterDate) {
+			continue
+		}
+		if !item.RegisteredAt.Before(exclusiveBefore) {
+			continue
+		}
+		ids = append(ids, item.ID)
+	}
+	return ids
+}

--- a/internal/niconico/rate_limiter.go
+++ b/internal/niconico/rate_limiter.go
@@ -1,0 +1,53 @@
+package niconico
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// RateLimiter enforces a minimum interval between requests.
+type RateLimiter struct {
+	mu       sync.Mutex
+	interval time.Duration
+	nextTime time.Time
+}
+
+// NewRateLimiter builds a RateLimiter from rate and minimum interval settings.
+func NewRateLimiter(rateLimit float64, minInterval time.Duration) *RateLimiter {
+	interval := time.Duration(0)
+	if rateLimit > 0 {
+		seconds := float64(time.Second) / rateLimit
+		if seconds < float64(time.Nanosecond) {
+			interval = time.Nanosecond
+		} else {
+			interval = time.Duration(seconds)
+		}
+	}
+	if minInterval > interval {
+		interval = minInterval
+	}
+	if interval <= 0 {
+		return nil
+	}
+	return &RateLimiter{interval: interval}
+}
+
+// Wait blocks until the next request slot is available.
+func (l *RateLimiter) Wait(ctx context.Context, minDelay time.Duration) error {
+	if l == nil {
+		return sleepFn(ctx, minDelay)
+	}
+	if minDelay < 0 {
+		minDelay = 0
+	}
+	now := timeNow()
+	readyAt := now.Add(minDelay)
+	l.mu.Lock()
+	if l.nextTime.After(readyAt) {
+		readyAt = l.nextTime
+	}
+	l.nextTime = readyAt.Add(l.interval)
+	l.mu.Unlock()
+	return sleepFn(ctx, readyAt.Sub(now))
+}

--- a/internal/niconico/retry.go
+++ b/internal/niconico/retry.go
@@ -1,0 +1,143 @@
+package niconico
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	retryBaseDelay = 100 * time.Millisecond
+	retryMaxDelay  = 30 * time.Second
+)
+
+var (
+	timeNow = time.Now
+	sleepFn = sleepWithContext
+)
+
+// closeAndIsNotFound closes the response body and reports whether the status is 404.
+func closeAndIsNotFound(res *http.Response) bool {
+	if res == nil || res.StatusCode != http.StatusNotFound {
+		return false
+	}
+	_ = res.Body.Close()
+	return true
+}
+
+// evaluateResponse validates HTTP responses and returns any retry delay needed.
+func evaluateResponse(res *http.Response) (*http.Response, time.Duration, error) {
+	if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusNotFound {
+		return res, 0, nil
+	}
+	retryAfter := retryAfterDelay(res)
+	_ = res.Body.Close()
+	return nil, retryAfter, fmt.Errorf("unexpected status: %d", res.StatusCode)
+}
+
+// nextRetryDelay calculates the next backoff delay, honoring Retry-After when larger.
+func nextRetryDelay(retryAfter time.Duration, attempt int) time.Duration {
+	wait := min(retryBaseDelay*time.Duration(1<<uint(attempt-1)), retryMaxDelay)
+	return max(retryAfter, wait)
+}
+
+// retriesRequest issues a GET request with retries and rate limiting.
+func retriesRequest(ctx context.Context, url string, httpClientTimeout time.Duration, retries int, limiter *RateLimiter) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Frontend-Id", "6")
+	req.Header.Set("Accept", "*/*")
+	client := &http.Client{Timeout: httpClientTimeout}
+
+	var lastErr error
+
+	delay := time.Duration(0)
+	for attempt := 1; attempt <= retries; attempt++ {
+		if err := waitBeforeAttempt(ctx, limiter, delay); err != nil {
+			return nil, err
+		}
+		delay = 0
+
+		res, err := client.Do(req)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				if res != nil {
+					_ = res.Body.Close()
+				}
+				return nil, err
+			}
+			if res != nil {
+				_ = res.Body.Close()
+			}
+			lastErr = err
+		} else {
+			var retryAfter time.Duration
+			res, retryAfter, err = evaluateResponse(res)
+			if err == nil {
+				return res, nil
+			}
+			lastErr = err
+			delay = retryAfter
+		}
+
+		if attempt == retries {
+			return nil, lastErr
+		}
+
+		delay = nextRetryDelay(delay, attempt)
+	}
+
+	return nil, lastErr
+}
+
+// sleepWithContext waits for the duration or returns early on context cancellation.
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// waitBeforeAttempt applies any delay and rate limiting before a request attempt.
+func waitBeforeAttempt(ctx context.Context, limiter *RateLimiter, delay time.Duration) error {
+	if limiter == nil {
+		return sleepFn(ctx, delay)
+	}
+	return limiter.Wait(ctx, delay)
+}
+
+// retryAfterDelay parses Retry-After for 429 responses and returns a delay.
+func retryAfterDelay(res *http.Response) time.Duration {
+	if res == nil || res.StatusCode != http.StatusTooManyRequests {
+		return 0
+	}
+	value := strings.TrimSpace(res.Header.Get("Retry-After"))
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	if parsed, err := http.ParseTime(value); err == nil {
+		if delay := parsed.Sub(timeNow()); delay > 0 {
+			return delay
+		}
+	}
+	return 0
+}


### PR DESCRIPTION
## Summary

Add effective per-target page concurrency support and split niconico page fetching into reusable helpers.

## What / Why

- Add `RootConfig.PageConcurrency`, `--page-concurrency`, default `1`, validation, help text, and focused tests.
- Extract page fetch/filter helpers plus retry/rate-limit helpers from `internal/niconico/client.go`.
- Use `totalCount` to schedule bounded parallel page fetches for user videos and mylists when `--page-concurrency > 1`.
- Preserve compatibility with sequential fetching for `--page-concurrency 1`, `--max-videos`, and unknown totals.
- Document request multiplier and rate-limit guidance in README, Japanese README, and design docs.

## Related issues

Closes #265
Closes #266
Closes #267
Closes #270

## Testing

```bash
go test ./cmd -run 'TestPageConcurrency|TestRunRootCmdPageConcurrencyFetches' -count=1
go test ./internal/niconico -count=1
go test ./internal/niconico -run 'TestGetVideoListPageConcurrency(StopsSchedulingAfterFetchError|StopsAtEmptyPage|PreservesPageOrder|ReturnsPartialIDsOnFetchError)' -count=1
go test -race ./internal/niconico -run 'TestGetVideoListPageConcurrency(StopsSchedulingAfterFetchError|StopsAtEmptyPage|PreservesPageOrder|ReturnsPartialIDsOnFetchError)' -count=100
go test -race ./internal/niconico -run 'TestGetVideoListPageConcurrency(IgnoresErrorAfterEmptyPage|ReturnsEarlierPageBeforeLaterEmptyPage|CancelsToEmptyResult|StopsSchedulingAfterFetchError|StopsAtEmptyPage|PreservesPageOrder|ReturnsPartialIDsOnFetchError)' -count=50
go test -race ./cmd -run 'TestRunRootCmdPageConcurrencyFetches(UserPagesBeforeSorting|MylistPages)' -count=50
go test ./...
go vet ./...
go test -race ./...
golangci-lint run ./...
go mod tidy
go generate ./...
git diff --exit-code -- go.mod go.sum
git diff --check
```

## Fix log

- 2026-06-14: add page-concurrency flag/validation tests and split fetch/retry/rate-limit helpers.
- 2026-06-14: address review by wiring page-concurrency into actual page fetching and documenting it in the Japanese README.
- 2026-06-14: address review by stopping parallel collection at the first empty/404/error page, preventing later-page output and post-stop fetches.
- 2026-06-15: address review by ordering parallel stop handling by page number, preserving earlier assigned pages, propagating cancellation, and removing fixed test timeouts.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [x] Checked release-generated third-party notices if dependencies changed
