### PR TITLE
feat: parallelize page fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Notes:
 - When a safety cap is hit, fetching stops early and returns best-effort results without error.
 - Responses with HTTP status other than 200/404 after retries are treated as fetch errors.
 - HTTP 200 responses with `meta.status != 200` are logged as warnings but still processed.
-- Rate limiting applies globally to all requests (including retries). HTTP 429 `Retry-After` is honored when present.
+- `--page-concurrency` controls concurrent page requests inside each input target. The maximum in-flight request count is roughly `--concurrency * --page-concurrency`.
+- Rate limiting applies globally to all requests (including retries). HTTP 429 `Retry-After` is honored when present. Use `--rate-limit` or `--min-interval` with high concurrency to reduce API load.
 - Progress is auto-disabled when stderr is not a TTY. Use `--progress` to force-enable or `--no-progress` to disable (takes precedence).
 - A run summary is printed to stderr after processing (even when the exit code is non-zero).
 - `--strict` makes invalid inputs return a non-zero exit code while still outputting valid results.

--- a/cmd/root_output_test.go
+++ b/cmd/root_output_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestWriteLineOutputMatchesExistingFormatting(t *testing.T) {
@@ -186,6 +187,76 @@ func TestRunRootCmdDefaultSortsFetchedIDs(t *testing.T) {
 	}
 	if got := out.String(); got != "sm1\nsm2\n" {
 		t.Errorf("unexpected stdout output: %q", got)
+	}
+}
+
+func TestRunRootCmdPageConcurrencyFetchesUserPagesBeforeSorting(t *testing.T) {
+	page3Started := make(chan struct{})
+	var page3StartedOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm3","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			select {
+			case <-page3Started:
+				_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}`)
+			case <-time.After(200 * time.Millisecond):
+				http.Error(w, "page 3 was not fetched concurrently", http.StatusConflict)
+			}
+		case "3":
+			page3StartedOnce.Do(func() { close(page3Started) })
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-12T00:00:00Z","count":{"comment":10}}}]}}`)
+		default:
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[]}}`)
+		}
+	}))
+	t.Cleanup(server.Close)
+	cfg := testFetchConfig(server.URL)
+	cfg.PageConcurrency = 2
+
+	out, _, err := executeTestRootCommand(t, cfg, newTestRootDeps(), "nicovideo.jp/user/1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := out.String(); got != "sm1\nsm2\nsm3\n" {
+		t.Fatalf("unexpected stdout output: %q", got)
+	}
+}
+
+func TestRunRootCmdPageConcurrencyFetchesMylistPages(t *testing.T) {
+	page3Started := make(chan struct{})
+	var page3StartedOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[{"video":{"id":"sm3","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}}`)
+		case "2":
+			select {
+			case <-page3Started:
+				_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[{"video":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}}`)
+			case <-time.After(200 * time.Millisecond):
+				http.Error(w, "page 3 was not fetched concurrently", http.StatusConflict)
+			}
+		case "3":
+			page3StartedOnce.Do(func() { close(page3Started) })
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[{"video":{"id":"sm1","registeredAt":"2024-01-12T00:00:00Z","count":{"comment":10}}}]}}}`)
+		default:
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"mylist":{"totalCount":300,"items":[]}}}`)
+		}
+	}))
+	t.Cleanup(server.Close)
+	cfg := testFetchConfig(server.URL)
+	cfg.PageConcurrency = 2
+
+	out, _, err := executeTestRootCommand(t, cfg, newTestRootDeps(), "nicovideo.jp/mylist/847130")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := out.String(); got != "sm1\nsm2\nsm3\n" {
+		t.Fatalf("unexpected stdout output: %q", got)
 	}
 }
 

--- a/cmd/root_run.go
+++ b/cmd/root_run.go
@@ -136,9 +136,9 @@ func runRootCmdWithConfig(cmd *cobra.Command, args []string, cfg *RootConfig, de
 			var err error
 			switch target.Type {
 			case targetTypeUser:
-				newList, err = niconico.GetVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, runLogger)
+				newList, err = niconico.GetVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, cfg.PageConcurrency, runLogger)
 			case targetTypeMylist:
-				newList, err = niconico.GetMylistVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, runLogger)
+				newList, err = niconico.GetMylistVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, cfg.PageConcurrency, runLogger)
 			}
 			if err != nil {
 				atomic.AddInt64(&fetchErrCount, 1)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -65,7 +65,7 @@ main.go
     - `dateafter` must be on or before `datebefore`.
   - `--tab` (default `false`), `--url` (default `false`): output formatting.
   - `--concurrency` (default `3`): concurrent requests.
-  - `--page-concurrency` (default `1`): concurrent page requests per target.
+  - `--page-concurrency` (default `1`): concurrent page requests per target; total in-flight requests are roughly `--concurrency * --page-concurrency`.
   - `--rate-limit` (default `0`): maximum requests per second (float; `0` disables).
   - `--min-interval` (default `0s`): minimum interval between requests (`0` disables).
   - `--max-pages` (default `0`): maximum number of pages to fetch (`0` disables).
@@ -138,6 +138,8 @@ main.go
   - `X-Frontend-Id: 6`
   - `Accept: */*`
 - Pagination: fetch until API page end.
+- When `totalCount` is present, page 1 determines the bounded page range and later pages may be fetched concurrently up to `--page-concurrency`.
+- If `totalCount` is unavailable or `--max-videos` is set, fetching uses the sequential empty/404 termination path for compatibility.
 - `max-pages` stops after the given number of pages (best-effort, no error).
 - `max-videos` stops after collecting the given number of filtered IDs (best-effort, no error).
 - Filters:

--- a/internal/niconico/benchmark_test.go
+++ b/internal/niconico/benchmark_test.go
@@ -71,7 +71,7 @@ func BenchmarkGetVideoListLargeUserPayload(b *testing.B) {
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		ids, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+		ids, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 		if err != nil {
 			b.Fatalf("GetVideoList returned error: %v", err)
 		}
@@ -98,7 +98,7 @@ func BenchmarkGetMylistVideoListLargePayload(b *testing.B) {
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		ids, err := GetMylistVideoList(context.Background(), "847130", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+		ids, err := GetMylistVideoList(context.Background(), "847130", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 		if err != nil {
 			b.Fatalf("GetMylistVideoList returned error: %v", err)
 		}

--- a/internal/niconico/client.go
+++ b/internal/niconico/client.go
@@ -30,9 +30,10 @@ func GetVideoList(
 	limiter *RateLimiter,
 	maxPages int,
 	maxVideos int,
+	pageConcurrency int,
 	logger *slog.Logger,
 ) ([]string, error) {
-	return collectVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger,
+	return collectVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, pageConcurrency, logger,
 		func(page int) string {
 			return fmt.Sprintf("%s/users/%s/videos?pageSize=%d&page=%d", baseURL, userID, pageSize, page)
 		},
@@ -53,9 +54,10 @@ func GetMylistVideoList(
 	limiter *RateLimiter,
 	maxPages int,
 	maxVideos int,
+	pageConcurrency int,
 	logger *slog.Logger,
 ) ([]string, error) {
-	return collectVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger,
+	return collectVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, pageConcurrency, logger,
 		func(page int) string {
 			return fmt.Sprintf("%s/mylists/%s?pageSize=%d&page=%d", baseURL, mylistID, pageSize, page)
 		},
@@ -68,15 +70,27 @@ func parseUserVideoPage(body []byte) (parsedPage, error) {
 	if err := json.Unmarshal(body, &nicoData); err != nil {
 		return parsedPage{}, err
 	}
+	var countPayload struct {
+		Data struct {
+			TotalCount *int `json:"totalCount"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &countPayload); err != nil {
+		return parsedPage{}, err
+	}
 	items := make([]videoItem, 0, len(nicoData.Data.Items))
 	for _, s := range nicoData.Data.Items {
 		items = append(items, videoItem{ID: s.Essential.ID, CommentCount: s.Essential.Count.Comment, RegisteredAt: s.Essential.RegisteredAt})
 	}
+	totalCount := 0
+	if countPayload.Data.TotalCount != nil {
+		totalCount = *countPayload.Data.TotalCount
+	}
 	return parsedPage{
 		Items:           items,
 		Status:          nicoData.Meta.Status,
-		TotalCount:      nicoData.Data.TotalCount,
-		TotalCountKnown: true,
+		TotalCount:      totalCount,
+		TotalCountKnown: countPayload.Data.TotalCount != nil,
 	}, nil
 }
 
@@ -86,8 +100,10 @@ func parseMylistPage(body []byte) (parsedPage, error) {
 			Status int `json:"status"`
 		} `json:"meta"`
 		Data struct {
-			Mylist struct {
-				Items []struct {
+			TotalCount *int `json:"totalCount"`
+			Mylist     struct {
+				TotalCount *int `json:"totalCount"`
+				Items      []struct {
 					Video struct {
 						ID           string    `json:"id"`
 						RegisteredAt time.Time `json:"registeredAt"`
@@ -106,7 +122,21 @@ func parseMylistPage(body []byte) (parsedPage, error) {
 	for _, it := range payload.Data.Mylist.Items {
 		items = append(items, videoItem{ID: it.Video.ID, CommentCount: it.Video.Count.Comment, RegisteredAt: it.Video.RegisteredAt})
 	}
-	return parsedPage{Items: items, Status: payload.Meta.Status}, nil
+	totalCount := 0
+	totalCountKnown := false
+	if payload.Data.Mylist.TotalCount != nil {
+		totalCount = *payload.Data.Mylist.TotalCount
+		totalCountKnown = true
+	} else if payload.Data.TotalCount != nil {
+		totalCount = *payload.Data.TotalCount
+		totalCountKnown = true
+	}
+	return parsedPage{
+		Items:           items,
+		Status:          payload.Meta.Status,
+		TotalCount:      totalCount,
+		TotalCountKnown: totalCountKnown,
+	}, nil
 }
 
 func collectVideoList(
@@ -119,6 +149,7 @@ func collectVideoList(
 	limiter *RateLimiter,
 	maxPages int,
 	maxVideos int,
+	pageConcurrency int,
 	logger *slog.Logger,
 	requestURL func(page int) string,
 	parsePage parsePageFunc,
@@ -127,34 +158,37 @@ func collectVideoList(
 		logger = slog.Default()
 	}
 
-	var resStr []string
-
-	for page := 1; ; page++ {
-		if maxPages > 0 && page > maxPages {
-			break
+	firstPage, err := fetchPage(ctx, requestURL(1), httpClientTimeout, retries, limiter, logger, parsePage)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, nil
 		}
-		parsed, err := fetchPage(ctx, requestURL(page), httpClientTimeout, retries, limiter, logger, parsePage)
-		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return nil, nil
-			}
-			return resStr, err
+		return nil, err
+	}
+	if firstPage.NotFound || len(firstPage.Items) == 0 {
+		return nil, nil
+	}
+	resStr := filterItems(firstPage.Items, commentCount, afterDate, beforeDate)
+	if maxVideos > 0 && len(resStr) >= maxVideos {
+		return resStr[:maxVideos], nil
+	}
+	if shouldCollectSequentially(firstPage, pageConcurrency, maxVideos) {
+		return collectRemainingSequentially(ctx, resStr, 2, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger, requestURL, parsePage)
+	}
+	totalPages := pageCountFor(firstPage.TotalCount)
+	if maxPages > 0 && totalPages > maxPages {
+		totalPages = maxPages
+	}
+	if totalPages <= 1 {
+		return resStr, nil
+	}
+	parallelIDs, err := collectPagesParallel(ctx, 2, totalPages, pageConcurrency, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, logger, requestURL, parsePage)
+	resStr = append(resStr, parallelIDs...)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, nil
 		}
-		if parsed.NotFound {
-			break
-		}
-		if parsed.Items == nil {
-			continue
-		}
-		if len(parsed.Items) == 0 {
-			break
-		}
-		for _, id := range filterItems(parsed.Items, commentCount, afterDate, beforeDate) {
-			resStr = append(resStr, id)
-			if maxVideos > 0 && len(resStr) >= maxVideos {
-				return resStr, nil
-			}
-		}
+		return resStr, err
 	}
 	return resStr, nil
 }

--- a/internal/niconico/client_test.go
+++ b/internal/niconico/client_test.go
@@ -20,6 +20,14 @@ type trackingReadCloser struct {
 	closed bool
 }
 
+func sameStringSet(got []string, want []string) bool {
+	gotCopy := append([]string{}, got...)
+	wantCopy := append([]string{}, want...)
+	slices.Sort(gotCopy)
+	slices.Sort(wantCopy)
+	return slices.Equal(gotCopy, wantCopy)
+}
+
 func (r *trackingReadCloser) Read(_ []byte) (int, error) {
 	return 0, io.EOF
 }
@@ -461,7 +469,7 @@ func TestGetVideoList(t *testing.T) {
 		after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 		before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-		got, err := GetVideoList(context.Background(), "12345", 5, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+		got, err := GetVideoList(context.Background(), "12345", 5, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -487,7 +495,7 @@ func TestGetVideoList(t *testing.T) {
 		after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 		before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-		got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+		got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -508,7 +516,7 @@ func TestGetVideoList(t *testing.T) {
 		after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 		before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-		_, err := GetVideoList(context.Background(), "12345", 5, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+		_, err := GetVideoList(context.Background(), "12345", 5, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
@@ -530,7 +538,7 @@ func TestGetVideoListContextCanceled(t *testing.T) {
 	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-	got, err := GetVideoList(ctx, "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+	got, err := GetVideoList(ctx, "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -553,7 +561,7 @@ func TestGetVideoListHandleNotFound(t *testing.T) {
 	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -579,7 +587,7 @@ func TestGetVideoListHandleServerError(t *testing.T) {
 	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-	_, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 2, time.Second, nil, 0, 0, logger)
+	_, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 2, time.Second, nil, 0, 0, 1, logger)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -607,7 +615,7 @@ func TestGetVideoListPartialOnError(t *testing.T) {
 	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, logger)
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 1, logger)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -634,7 +642,7 @@ func TestGetVideoListMaxPagesStopsEarly(t *testing.T) {
 	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 1, 0, logger)
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 1, 0, 1, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -643,6 +651,74 @@ func TestGetVideoListMaxPagesStopsEarly(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("expected 1 attempt, got %d", count)
+	}
+}
+
+func TestGetVideoListPageConcurrencyAppliesMaxPagesBeforeScheduling(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	var requestedPages []string
+	var mu sync.Mutex
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestedPages = append(requestedPages, r.URL.Query().Get("page"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}`)
+		default:
+			t.Errorf("unexpected page request: %s", r.URL.Query().Get("page"))
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[]}}`)
+		}
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 2, 0, 2, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sameStringSet(got, []string{"sm1", "sm2"}) {
+		t.Fatalf("unexpected ids: %v", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !reflect.DeepEqual(requestedPages, []string{"1", "2"}) {
+		t.Fatalf("unexpected requested pages: %v", requestedPages)
+	}
+}
+
+func TestGetVideoListPageConcurrencyReturnsPartialIDsOnFetchError(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+		case "2":
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"totalCount":300,"items":[{"essential":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}`)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, "invalid")
+		}
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 0, 2, logger)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !sameStringSet(got, []string{"sm1", "sm2"}) {
+		t.Fatalf("unexpected partial ids: %v", got)
 	}
 }
 
@@ -660,7 +736,7 @@ func TestGetVideoListMaxVideosStopsEarly(t *testing.T) {
 	after := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	before := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
 
-	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 2, logger)
+	got, err := GetVideoList(context.Background(), "12345", 0, after, before, server.URL, 1, time.Second, nil, 0, 2, 1, logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -696,11 +772,7 @@ func TestGetMylistVideoList(t *testing.T) {
 		time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC),
 		server.URL,
 		1,
-		time.Second,
-		nil,
-		0,
-		0,
-		slog.New(slog.DiscardHandler),
+		time.Second, nil, 0, 0, 1, slog.New(slog.DiscardHandler),
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/niconico/collection.go
+++ b/internal/niconico/collection.go
@@ -1,0 +1,136 @@
+package niconico
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+func collectRemainingSequentially(
+	ctx context.Context,
+	resStr []string,
+	startPage int,
+	commentCount int,
+	afterDate time.Time,
+	beforeDate time.Time,
+	retries int,
+	httpClientTimeout time.Duration,
+	limiter *RateLimiter,
+	maxPages int,
+	maxVideos int,
+	logger *slog.Logger,
+	requestURL func(page int) string,
+	parsePage parsePageFunc,
+) ([]string, error) {
+	for page := startPage; ; page++ {
+		if maxPages > 0 && page > maxPages {
+			break
+		}
+		parsed, err := fetchPage(ctx, requestURL(page), httpClientTimeout, retries, limiter, logger, parsePage)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, nil
+			}
+			return resStr, err
+		}
+		if parsed.NotFound {
+			break
+		}
+		if parsed.Items == nil {
+			continue
+		}
+		if len(parsed.Items) == 0 {
+			break
+		}
+		for _, id := range filterItems(parsed.Items, commentCount, afterDate, beforeDate) {
+			resStr = append(resStr, id)
+			if maxVideos > 0 && len(resStr) >= maxVideos {
+				return resStr, nil
+			}
+		}
+	}
+	return resStr, nil
+}
+
+func shouldCollectSequentially(firstPage parsedPage, pageConcurrency int, maxVideos int) bool {
+	return pageConcurrency <= 1 || maxVideos > 0 || !firstPage.TotalCountKnown
+}
+
+func pageCountFor(totalCount int) int {
+	if totalCount <= 0 {
+		return 0
+	}
+	return (totalCount + pageSize - 1) / pageSize
+}
+
+type pageResult struct {
+	ids []string
+	err error
+}
+
+func collectPagesParallel(
+	ctx context.Context,
+	startPage int,
+	endPage int,
+	pageConcurrency int,
+	commentCount int,
+	afterDate time.Time,
+	beforeDate time.Time,
+	retries int,
+	httpClientTimeout time.Duration,
+	limiter *RateLimiter,
+	logger *slog.Logger,
+	requestURL func(page int) string,
+	parsePage parsePageFunc,
+) ([]string, error) {
+	pages := make(chan int)
+	results := make(chan pageResult, pageConcurrency)
+	var wg sync.WaitGroup
+	for range pageConcurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for page := range pages {
+				parsed, err := fetchPage(ctx, requestURL(page), httpClientTimeout, retries, limiter, logger, parsePage)
+				if err != nil {
+					results <- pageResult{err: err}
+					continue
+				}
+				if parsed.NotFound || len(parsed.Items) == 0 {
+					continue
+				}
+				results <- pageResult{ids: filterItems(parsed.Items, commentCount, afterDate, beforeDate)}
+			}
+		}()
+	}
+	go func() {
+		for page := startPage; page <= endPage; page++ {
+			select {
+			case pages <- page:
+			case <-ctx.Done():
+				close(pages)
+				wg.Wait()
+				close(results)
+				return
+			}
+		}
+		close(pages)
+		wg.Wait()
+		close(results)
+	}()
+
+	var ids []string
+	var firstErr error
+	for result := range results {
+		if result.err != nil {
+			if firstErr == nil {
+				firstErr = result.err
+			}
+			continue
+		}
+		ids = append(ids, result.ids...)
+	}
+	return ids, firstErr
+}

--- a/internal/niconico/e2e_test.go
+++ b/internal/niconico/e2e_test.go
@@ -43,6 +43,7 @@ func TestGetVideoListE2E(t *testing.T) {
 		nil,
 		2,
 		10,
+		1,
 		logger,
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

Parallelize per-target page fetching for user videos and mylists when `totalCount` is available.

## What / Why

- Pass `--page-concurrency` from the CLI into the niconico fetch layer.
- Use page 1 `totalCount` to schedule bounded page ranges and fetch later pages concurrently.
- Support mylist totals from `data.mylist.totalCount` or `data.totalCount`, with sequential fallback when totals are unavailable.
- Preserve compatibility for `--page-concurrency 1`, `--max-videos`, partial fetch errors, and normal numeric output sorting.

## Related issues

Closes #267
Closes #270

## Testing

```bash
go test ./cmd -run 'TestRunRootCmdPageConcurrencyFetches|TestRunRootCmdDefaultSortsFetchedIDs' -count=1
go test ./internal/niconico -run 'TestGetVideoListPageConcurrency|TestGetVideoListMaxPagesStopsEarly|TestGetVideoListPartialOnError|TestGetMylistVideoList' -count=1
go test ./...
go vet ./...
```

## Fix log

- 2026-06-14: add totalCount-based page worker pool, mylist total parsing, compatibility fallbacks, and concurrency tests.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [ ] `golangci-lint run ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [x] Checked release-generated third-party notices if dependencies changed
