### PR TITLE
fix: handle no-sort max-videos edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,13 @@ Notes:
 - Setting `concurrency`, `page-concurrency`, or `retries` to a value less than 1, or `timeout` to a value less than or equal to 0, will cause a runtime error.
 - `--dateafter` must be on or before `--datebefore`; inverted ranges return a validation error.
 - `--max-pages` and `--max-videos` are safety caps; `0` disables them.
+- For normal line output and JSON output, `--max-videos N` is a per-target fetch cap: each input target may collect up to N filtered IDs before output formatting, dedupe, sorting, or JSON flattening.
+- For unordered line output (`--no-sort` without `--json`), `--max-videos N` is a global emitted-output cap: the first N IDs that reach the writer are emitted, then remaining fetches are canceled best-effort.
+- With `--no-sort --dedupe --max-videos N`, the cap applies to emitted unique IDs. The command may read more than N raw IDs to find N unique IDs.
 - When a safety cap is hit, fetching stops early and returns best-effort results without error.
 - Responses with HTTP status other than 200/404 after retries are treated as fetch errors.
 - HTTP 200 responses with `meta.status != 200` are logged as warnings but still processed.
-- `--page-concurrency` controls concurrent page requests inside each input target. The maximum in-flight request count is roughly `--concurrency * --page-concurrency`.
+- `--page-concurrency` controls concurrent page requests inside each input target only when the API reports `totalCount` and `--max-videos` is not set. The maximum in-flight request count is roughly `--concurrency * --page-concurrency` in that bounded-page path.
 - Rate limiting applies globally to all requests (including retries). HTTP 429 `Retry-After` is honored when present. Use `--rate-limit` or `--min-interval` with high concurrency to reduce API load.
 - Progress is auto-disabled when stderr is not a TTY. Use `--progress` to force-enable or `--no-progress` to disable (takes precedence).
 - A run summary is printed to stderr after processing (even when the exit code is non-zero).
@@ -93,7 +96,6 @@ Notes:
 - Normal line output sorts IDs by numeric video ID unless `--no-sort` is set.
 - `--dedupe` removes duplicate video IDs before sorting/output. With `--no-sort`, the first occurrence that reaches the writer is kept.
 - `--no-sort` is an unordered fast mode for line output: input target order, page order, and API item order are not guaranteed. Results are written as soon as target fetches finish.
-- With `--no-sort --max-videos N`, the first N IDs that reach the writer are emitted and remaining fetches are canceled best-effort.
 - `--json` emits a single JSON object to stdout. `--tab`/`--url` do not affect JSON `items`, and the summary still prints to stderr.
 - In JSON output, `targets` include `type` (`user` or `mylist`) and `id`, sorted by type and numeric id in ascending order.
 

--- a/cmd/root_fast_unordered.go
+++ b/cmd/root_fast_unordered.go
@@ -48,7 +48,7 @@ func runRootCmdFastUnordered(cmd *cobra.Command, args []string, cfg *RootConfig,
 	defer cancel()
 
 	errWriter := errWriterFor(cmd)
-	stream := streamInputsWithConfig(cmd, args, cfg, deps)
+	stream := streamInputsWithConfig(ctx, cmd, args, cfg, deps)
 	limiter := niconico.NewRateLimiter(cfg.RateLimit, cfg.MinInterval)
 	var totalInputs int64
 	var validInputs int64
@@ -134,7 +134,7 @@ inputLoop:
 			defer wg.Done()
 			defer func() { <-sem }()
 			defer addProgress()
-			newList, err := fetchTargetList(ctx, target, cfg, afterDate, beforeDate, limiter, runLogger)
+			newList, err := fetchTargetListFastUnordered(ctx, target, cfg, afterDate, beforeDate, limiter, runLogger)
 			if err != nil {
 				atomic.AddInt64(&fetchErrCount, 1)
 				errCh <- err

--- a/cmd/root_fast_unordered_input_test.go
+++ b/cmd/root_fast_unordered_input_test.go
@@ -12,6 +12,66 @@ import (
 	"time"
 )
 
+type closeUnblocksReader struct {
+	line string
+
+	closeOnce sync.Once
+	readOnce  sync.Once
+	closed    chan struct{}
+	closeDone chan struct{}
+}
+
+func newCloseUnblocksReader(line string) *closeUnblocksReader {
+	return &closeUnblocksReader{
+		line:      line,
+		closed:    make(chan struct{}),
+		closeDone: make(chan struct{}),
+	}
+}
+
+func (r *closeUnblocksReader) Read(p []byte) (int, error) {
+	sent := false
+	r.readOnce.Do(func() {
+		sent = true
+	})
+	if sent {
+		return copy(p, r.line), nil
+	}
+	<-r.closed
+	return 0, io.EOF
+}
+
+func (r *closeUnblocksReader) Close() error {
+	r.closeOnce.Do(func() {
+		close(r.closed)
+		close(r.closeDone)
+	})
+	return nil
+}
+
+func waitForReaderClose(t *testing.T, reader *closeUnblocksReader) {
+	t.Helper()
+	select {
+	case <-reader.closeDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected canceled input producer to close blocked reader")
+	}
+}
+
+func newSingleVideoServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") != "1" {
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
 func TestRunRootCmdNoSortMaxVideosReturnsInputFileReadErrorAfterCap(t *testing.T) {
 	requestStarted := make(chan struct{})
 	writerDone := make(chan struct{})
@@ -59,6 +119,85 @@ func TestRunRootCmdNoSortMaxVideosReturnsInputFileReadErrorAfterCap(t *testing.T
 	case <-time.After(time.Second):
 		t.Fatal("expected command to finish with input file read error")
 	}
+}
+
+func TestRunRootCmdNoSortMaxVideosClosesBlockedStdinInputStream(t *testing.T) {
+	server := newSingleVideoServer(t)
+	reader := newCloseUnblocksReader("nicovideo.jp/user/1\n")
+	t.Cleanup(func() { _ = reader.Close() })
+
+	cfg := testFetchConfig(server.URL)
+	cfg.NoSortOutput = true
+	cfg.MaxVideos = 1
+	cfg.ReadStdin = true
+	cmd, out, errOut := newTestRootCommand(t, cfg, newTestRootDeps())
+	cmd.SetIn(reader)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- cmd.Execute()
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected command to finish after max-videos cancellation")
+	}
+	if got := strings.Fields(out.String()); len(got) != 1 || got[0] != "sm1" {
+		t.Fatalf("unexpected stdout output: %q", out.String())
+	}
+	if got := errOut.String(); !strings.Contains(got, "output_count=1") {
+		t.Fatalf("expected output_count=1 summary, got %q", got)
+	}
+	waitForReaderClose(t, reader)
+}
+
+func TestRunRootCmdNoSortMaxVideosClosesBlockedInputFileInputStream(t *testing.T) {
+	server := newSingleVideoServer(t)
+	reader := newCloseUnblocksReader("nicovideo.jp/user/1\n")
+	t.Cleanup(func() { _ = reader.Close() })
+
+	cfg := testFetchConfig(server.URL)
+	cfg.NoSortOutput = true
+	cfg.MaxVideos = 1
+	cfg.InputFilePath = "dummy"
+	deps := newTestRootDeps()
+	deps.OpenInputFile = func(string) (io.ReadCloser, error) { return reader, nil }
+
+	out, errOut, err := executeTestRootCommand(t, cfg, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.Fields(out.String()); len(got) != 1 || got[0] != "sm1" {
+		t.Fatalf("unexpected stdout output: %q", out.String())
+	}
+	if got := errOut.String(); !strings.Contains(got, "output_count=1") {
+		t.Fatalf("expected output_count=1 summary, got %q", got)
+	}
+	waitForReaderClose(t, reader)
+}
+
+func TestRunRootCmdNoSortWriteErrorDoesNotWaitForBlockedInput(t *testing.T) {
+	server := newSingleVideoServer(t)
+	reader := newCloseUnblocksReader("nicovideo.jp/user/1\n")
+	t.Cleanup(func() { _ = reader.Close() })
+
+	cfg := testFetchConfig(server.URL)
+	cfg.NoSortOutput = true
+	cfg.InputFilePath = "dummy"
+	writeErr := errors.New("stdout failed")
+	deps := newTestRootDeps()
+	deps.OpenInputFile = func(string) (io.ReadCloser, error) { return reader, nil }
+	deps.Stdout = errorWriter{err: writeErr}
+
+	_, _, err := executeTestRootCommand(t, cfg, deps)
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("expected stdout error, got %v", err)
+	}
+	waitForReaderClose(t, reader)
 }
 
 func TestRunRootCmdNoSortContextCancelDoesNotWaitForBlockedInputErrors(t *testing.T) {

--- a/cmd/root_fast_unordered_test.go
+++ b/cmd/root_fast_unordered_test.go
@@ -127,6 +127,33 @@ func TestRunRootCmdNoSortDedupeOutputsEachIDOnce(t *testing.T) {
 	}
 }
 
+func TestRunRootCmdNoSortDedupeMaxVideosEmitsEnoughUniqueIDs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") != "1" {
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[]}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}},{"essential":{"id":"sm1","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}},{"essential":{"id":"sm2","registeredAt":"2024-01-12T00:00:00Z","count":{"comment":10}}}]}}`)
+	}))
+	t.Cleanup(server.Close)
+	cfg := testFetchConfig(server.URL)
+	cfg.NoSortOutput = true
+	cfg.DedupeOutput = true
+	cfg.MaxVideos = 2
+
+	out, errOut, err := executeTestRootCommand(t, cfg, newTestRootDeps(), "nicovideo.jp/user/1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := sortedLines(out.String()); !sameStringSet(got, []string{"sm1", "sm2"}) {
+		t.Fatalf("expected sm1 and sm2 stdout output, got %q", out.String())
+	}
+	if got := errOut.String(); !strings.Contains(got, "output_count=2") {
+		t.Fatalf("expected output_count=2 summary, got %q", got)
+	}
+}
+
 func TestRunRootCmdNoSortMaxVideosCapsOutputAndSummary(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/root_fast_unordered_unique_fetch_test.go
+++ b/cmd/root_fast_unordered_unique_fetch_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRunRootCmdNoSortDedupeMaxVideosStopsAfterEnoughUniqueIDs(t *testing.T) {
+	var page3Requests int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = io.WriteString(w, userVideoPage(300, "sm1", "sm1"))
+		case "2":
+			_, _ = io.WriteString(w, userVideoPage(300, "sm2"))
+		default:
+			atomic.AddInt64(&page3Requests, 1)
+			_, _ = io.WriteString(w, userVideoPage(300, "sm3"))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := testFetchConfig(server.URL)
+	cfg.NoSortOutput = true
+	cfg.DedupeOutput = true
+	cfg.MaxVideos = 2
+	cfg.PageConcurrency = 4
+
+	out, errOut, err := executeTestRootCommand(t, cfg, newTestRootDeps(), "nicovideo.jp/user/1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := sortedLines(out.String()); !slices.Equal(got, []string{"sm1", "sm2"}) {
+		t.Fatalf("expected two unique output IDs, got %q", out.String())
+	}
+	if got := atomic.LoadInt64(&page3Requests); got != 0 {
+		t.Fatalf("expected unique cap to stop before page 3, got %d page 3 requests", got)
+	}
+	if got := errOut.String(); !strings.Contains(got, "output_count=2") {
+		t.Fatalf("expected output_count=2 summary, got %q", got)
+	}
+}
+
+func userVideoPage(totalCount int, ids ...string) string {
+	items := make([]string, 0, len(ids))
+	for i, id := range ids {
+		items = append(items, fmt.Sprintf(`{"essential":{"id":%q,"registeredAt":"2024-01-%02dT00:00:00Z","count":{"comment":10}}}`, id, i+1))
+	}
+	return fmt.Sprintf(`{"meta":{"status":200},"data":{"totalCount":%d,"items":[%s]}}`, totalCount, strings.Join(items, ","))
+}

--- a/cmd/root_fetch_target.go
+++ b/cmd/root_fetch_target.go
@@ -18,16 +18,30 @@ func fetchTargetListFastUnordered(
 	limiter *niconico.RateLimiter,
 	runLogger *slog.Logger,
 ) ([]string, error) {
-	maxVideos := maxVideosForFastUnorderedFetch(cfg)
-	return fetchTargetListWithMaxVideos(ctx, target, cfg, afterDate, beforeDate, limiter, runLogger, maxVideos)
+	if cfg.DedupeOutput && cfg.MaxVideos > 0 {
+		return fetchTargetUniqueList(ctx, target, cfg, afterDate, beforeDate, limiter, runLogger)
+	}
+	return fetchTargetListWithMaxVideos(ctx, target, cfg, afterDate, beforeDate, limiter, runLogger, cfg.MaxVideos)
 }
 
-// maxVideosForFastUnorderedFetch returns the per-target fetch cap for fast unordered output.
-func maxVideosForFastUnorderedFetch(cfg *RootConfig) int {
-	if cfg.DedupeOutput && cfg.MaxVideos > 0 {
-		return 0
+// fetchTargetUniqueList fetches a target until it has enough unique filtered IDs.
+func fetchTargetUniqueList(
+	ctx context.Context,
+	target inputTarget,
+	cfg *RootConfig,
+	afterDate time.Time,
+	beforeDate time.Time,
+	limiter *niconico.RateLimiter,
+	runLogger *slog.Logger,
+) ([]string, error) {
+	switch target.Type {
+	case targetTypeUser:
+		return niconico.GetUniqueVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, runLogger)
+	case targetTypeMylist:
+		return niconico.GetUniqueMylistVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, runLogger)
+	default:
+		return nil, nil
 	}
-	return cfg.MaxVideos
 }
 
 // fetchTargetListWithMaxVideos fetches a target with an explicit per-target video cap.

--- a/cmd/root_fetch_target.go
+++ b/cmd/root_fetch_target.go
@@ -34,14 +34,17 @@ func fetchTargetUniqueList(
 	limiter *niconico.RateLimiter,
 	runLogger *slog.Logger,
 ) ([]string, error) {
+	collector := newUniqueIDCollector(cfg.MaxVideos)
+	var err error
 	switch target.Type {
 	case targetTypeUser:
-		return niconico.GetUniqueVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, runLogger)
+		err = niconico.VisitVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, collector.add, runLogger)
 	case targetTypeMylist:
-		return niconico.GetUniqueMylistVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, runLogger)
+		err = niconico.VisitMylistVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, collector.add, runLogger)
 	default:
 		return nil, nil
 	}
+	return collector.ids, err
 }
 
 // fetchTargetListWithMaxVideos fetches a target with an explicit per-target video cap.

--- a/cmd/root_fetch_target.go
+++ b/cmd/root_fetch_target.go
@@ -8,7 +8,8 @@ import (
 	"github.com/sh4869221b/go-nico-list/internal/niconico"
 )
 
-func fetchTargetList(
+// fetchTargetListFastUnordered fetches a target using the fast unordered cap semantics.
+func fetchTargetListFastUnordered(
 	ctx context.Context,
 	target inputTarget,
 	cfg *RootConfig,
@@ -17,11 +18,34 @@ func fetchTargetList(
 	limiter *niconico.RateLimiter,
 	runLogger *slog.Logger,
 ) ([]string, error) {
+	maxVideos := maxVideosForFastUnorderedFetch(cfg)
+	return fetchTargetListWithMaxVideos(ctx, target, cfg, afterDate, beforeDate, limiter, runLogger, maxVideos)
+}
+
+// maxVideosForFastUnorderedFetch returns the per-target fetch cap for fast unordered output.
+func maxVideosForFastUnorderedFetch(cfg *RootConfig) int {
+	if cfg.DedupeOutput && cfg.MaxVideos > 0 {
+		return 0
+	}
+	return cfg.MaxVideos
+}
+
+// fetchTargetListWithMaxVideos fetches a target with an explicit per-target video cap.
+func fetchTargetListWithMaxVideos(
+	ctx context.Context,
+	target inputTarget,
+	cfg *RootConfig,
+	afterDate time.Time,
+	beforeDate time.Time,
+	limiter *niconico.RateLimiter,
+	runLogger *slog.Logger,
+	maxVideos int,
+) ([]string, error) {
 	switch target.Type {
 	case targetTypeUser:
-		return niconico.GetVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, cfg.PageConcurrency, runLogger)
+		return niconico.GetVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, maxVideos, cfg.PageConcurrency, runLogger)
 	case targetTypeMylist:
-		return niconico.GetMylistVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, cfg.MaxVideos, cfg.PageConcurrency, runLogger)
+		return niconico.GetMylistVideoList(ctx, target.ID, cfg.Comment, afterDate, beforeDate, cfg.BaseURL, cfg.Retries, cfg.HTTPClientTimeout, limiter, cfg.MaxPages, maxVideos, cfg.PageConcurrency, runLogger)
 	default:
 		return nil, nil
 	}

--- a/cmd/root_input_test.go
+++ b/cmd/root_input_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -54,12 +55,43 @@ func TestStreamLinesFromFileReturnsCloseError(t *testing.T) {
 		return closeErrorReader{Reader: strings.NewReader("nicovideo.jp/user/1\n"), err: closeErr}, nil
 	}
 	out := make(chan string, 1)
-	count, err := streamLinesFromFile("dummy", out, deps)
+	count, err := streamLinesFromFile(context.Background(), "dummy", out, deps)
 	if !errors.Is(err, closeErr) {
 		t.Fatalf("expected close error, got %v", err)
 	}
 	if count != 1 {
 		t.Fatalf("unexpected count: %d", count)
+	}
+}
+
+func TestRunRootCmdInputFileOpenError(t *testing.T) {
+	openErr := errors.New("open failed")
+	cfg := newTestRootConfig()
+	cfg.InputFilePath = "dummy"
+	deps := newTestRootDeps()
+	deps.OpenInputFile = func(string) (io.ReadCloser, error) {
+		return nil, openErr
+	}
+
+	_, _, err := executeTestRootCommand(t, cfg, deps)
+	if !errors.Is(err, openErr) {
+		t.Fatalf("expected open error, got %v", err)
+	}
+}
+
+func TestRunRootCmdInputFileCloseError(t *testing.T) {
+	closeErr := errors.New("close failed")
+	server := newEmptyAPIServer(t)
+	cfg := testFetchConfig(server.URL)
+	cfg.InputFilePath = "dummy"
+	deps := newTestRootDeps()
+	deps.OpenInputFile = func(string) (io.ReadCloser, error) {
+		return closeErrorReader{Reader: strings.NewReader("nicovideo.jp/user/1\n"), err: closeErr}, nil
+	}
+
+	_, _, err := executeTestRootCommand(t, cfg, deps)
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("expected close error, got %v", err)
 	}
 }
 
@@ -108,6 +140,29 @@ func TestRunRootCmdInputReadErrorCancelsFetches(t *testing.T) {
 	case <-canceled:
 	case <-time.After(waitTimeout):
 		t.Fatal("expected request to be canceled")
+	}
+}
+
+func TestRunRootCmdJSONStdinReadError(t *testing.T) {
+	stdinErr := errors.New("stdin read error")
+	cfg := newTestRootConfig()
+	cfg.JSONOutput = true
+	cfg.ReadStdin = true
+	cmd, _, _ := newTestRootCommand(t, cfg, newTestRootDeps())
+	wait := make(chan struct{})
+	cmd.SetIn(blockingErrorReader{wait: wait, err: stdinErr})
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- cmd.Execute() }()
+
+	close(wait)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, stdinErr) {
+			t.Fatalf("expected stdin error, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected command to finish after stdin error")
 	}
 }
 

--- a/cmd/root_io.go
+++ b/cmd/root_io.go
@@ -2,10 +2,13 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"io"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/schollz/progressbar/v3"
 	"github.com/spf13/cobra"
@@ -18,6 +21,30 @@ type inputStream struct {
 	errs       <-chan error
 	totalKnown bool
 	total      int64
+}
+
+// onceReadCloser ensures shared cancellation and cleanup paths close a reader once.
+type onceReadCloser struct {
+	io.Reader
+	closeOnce sync.Once
+	closer    io.Closer
+	closeErr  error
+}
+
+// newOnceReadCloser wraps reader with idempotent close behavior.
+func newOnceReadCloser(reader io.ReadCloser) *onceReadCloser {
+	return &onceReadCloser{
+		Reader: reader,
+		closer: reader,
+	}
+}
+
+// Close closes the wrapped reader once and returns the first close error.
+func (r *onceReadCloser) Close() error {
+	r.closeOnce.Do(func() {
+		r.closeErr = r.closer.Close()
+	})
+	return r.closeErr
 }
 
 func newProgressBarWithConfig(cmd *cobra.Command, totalKnown bool, total int64, cfg *RootConfig, deps RootDeps) *progressbar.ProgressBar {
@@ -57,7 +84,7 @@ func defaultIsTerminal(w io.Writer) bool {
 	return false
 }
 
-func streamInputsWithConfig(cmd *cobra.Command, args []string, cfg *RootConfig, deps RootDeps) inputStream {
+func streamInputsWithConfig(ctx context.Context, cmd *cobra.Command, args []string, cfg *RootConfig, deps RootDeps) inputStream {
 	deps = normalizeRootDeps(deps)
 	out := make(chan string)
 	errCh := make(chan error, 1)
@@ -70,12 +97,14 @@ func streamInputsWithConfig(cmd *cobra.Command, args []string, cfg *RootConfig, 
 
 		count := 0
 		for _, arg := range args {
-			out <- arg
+			if !sendInput(ctx, out, arg) {
+				return
+			}
 			count++
 		}
 
 		if cfg.InputFilePath != "" {
-			n, err := streamLinesFromFile(cfg.InputFilePath, out, deps)
+			n, err := streamLinesFromFile(ctx, cfg.InputFilePath, out, deps)
 			count += n
 			if err != nil {
 				errCh <- err
@@ -88,7 +117,7 @@ func streamInputsWithConfig(cmd *cobra.Command, args []string, cfg *RootConfig, 
 			if cmd != nil {
 				reader = cmd.InOrStdin()
 			}
-			n, err := streamLines(reader, out)
+			n, err := streamLines(ctx, reader, out)
 			count += n
 			if err != nil {
 				errCh <- err
@@ -109,22 +138,40 @@ func streamInputsWithConfig(cmd *cobra.Command, args []string, cfg *RootConfig, 
 	}
 }
 
+// sendInput sends input unless ctx is canceled.
+func sendInput(ctx context.Context, out chan<- string, input string) bool {
+	select {
+	case out <- input:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
 // streamLinesFromFile streams trimmed lines from a file into out.
-func streamLinesFromFile(path string, out chan<- string, deps RootDeps) (int, error) {
+func streamLinesFromFile(ctx context.Context, path string, out chan<- string, deps RootDeps) (int, error) {
 	deps = normalizeRootDeps(deps)
-	file, err := deps.OpenInputFile(path)
+	openedFile, err := deps.OpenInputFile(path)
 	if err != nil {
 		return 0, err
 	}
-	count, err := streamLines(file, out)
-	if closeErr := file.Close(); err == nil && closeErr != nil {
+	file := newOnceReadCloser(openedFile)
+	count, err := streamLines(ctx, file, out)
+	if closeErr := file.Close(); err == nil && closeErr != nil && ctx.Err() == nil {
 		err = closeErr
 	}
 	return count, err
 }
 
 // streamLines streams non-empty trimmed lines from a reader into out.
-func streamLines(reader io.Reader, out chan<- string) (int, error) {
+func streamLines(ctx context.Context, reader io.Reader, out chan<- string) (int, error) {
+	done := make(chan struct{})
+	var closedOnCancel atomic.Bool
+	if closer, ok := reader.(io.Closer); ok {
+		go closeReaderOnCancel(ctx, closer, done, &closedOnCancel)
+		defer close(done)
+	}
+
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(make([]byte, 1024), 1024*1024)
 	count := 0
@@ -133,11 +180,26 @@ func streamLines(reader io.Reader, out chan<- string) (int, error) {
 		if line == "" {
 			continue
 		}
-		out <- line
+		if !sendInput(ctx, out, line) {
+			return count, nil
+		}
 		count++
 	}
 	if err := scanner.Err(); err != nil {
+		if closedOnCancel.Load() {
+			return count, nil
+		}
 		return count, err
 	}
 	return count, nil
+}
+
+// closeReaderOnCancel closes closer when ctx is canceled before scanning finishes.
+func closeReaderOnCancel(ctx context.Context, closer io.Closer, done <-chan struct{}, closedOnCancel *atomic.Bool) {
+	select {
+	case <-ctx.Done():
+		closedOnCancel.Store(true)
+		_ = closer.Close()
+	case <-done:
+	}
 }

--- a/cmd/root_max_videos_test.go
+++ b/cmd/root_max_videos_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRunRootCmdMaxVideosStopsSingleTargetPagination(t *testing.T) {
+	var page2Requests int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") != "1" {
+			atomic.AddInt64(&page2Requests, 1)
+			_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[{"essential":{"id":"sm2","registeredAt":"2024-01-11T00:00:00Z","count":{"comment":10}}}]}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"meta":{"status":200},"data":{"items":[{"essential":{"id":"sm1","registeredAt":"2024-01-10T00:00:00Z","count":{"comment":10}}}]}}`)
+	}))
+	t.Cleanup(server.Close)
+	cfg := testFetchConfig(server.URL)
+	cfg.MaxVideos = 1
+
+	out, _, err := executeTestRootCommand(t, cfg, newTestRootDeps(), "nicovideo.jp/user/1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := out.String(); got != "sm1\n" {
+		t.Fatalf("unexpected stdout output: %q", got)
+	}
+	if got := atomic.LoadInt64(&page2Requests); got != 0 {
+		t.Fatalf("expected max-videos to stop pagination before page 2, got %d page 2 requests", got)
+	}
+}

--- a/cmd/root_run.go
+++ b/cmd/root_run.go
@@ -48,7 +48,7 @@ func runRootCmdWithConfig(cmd *cobra.Command, args []string, cfg *RootConfig, de
 
 	var idList []string
 	var mu sync.Mutex
-	stream := streamInputsWithConfig(cmd, args, cfg, deps)
+	stream := streamInputsWithConfig(ctx, cmd, args, cfg, deps)
 	limiter := niconico.NewRateLimiter(cfg.RateLimit, cfg.MinInterval)
 	var totalInputs int64
 	var validInputs int64

--- a/cmd/root_unique_collector.go
+++ b/cmd/root_unique_collector.go
@@ -1,0 +1,30 @@
+package cmd
+
+type uniqueIDCollector struct {
+	limit int
+	ids   []string
+	seen  map[string]struct{}
+}
+
+// newUniqueIDCollector returns an empty collector with the specified unique ID limit.
+func newUniqueIDCollector(limit int) *uniqueIDCollector {
+	return &uniqueIDCollector{
+		limit: limit,
+		seen:  make(map[string]struct{}),
+	}
+}
+
+// add appends unseen IDs and reports whether pagination should continue.
+func (c *uniqueIDCollector) add(ids []string) bool {
+	for _, id := range ids {
+		if _, ok := c.seen[id]; ok {
+			continue
+		}
+		c.seen[id] = struct{}{}
+		c.ids = append(c.ids, id)
+		if c.limit > 0 && len(c.ids) >= c.limit {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/root_unique_collector_test.go
+++ b/cmd/root_unique_collector_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestUniqueIDCollectorLargeLimitStartsEmpty(t *testing.T) {
+	collector := newUniqueIDCollector(1_000_000_000)
+
+	if len(collector.ids) != 0 {
+		t.Fatalf("expected no collected IDs, got %d", len(collector.ids))
+	}
+	if len(collector.seen) != 0 {
+		t.Fatalf("expected no seen IDs, got %d", len(collector.seen))
+	}
+}
+
+func TestUniqueIDCollectorStopsAtUniqueLimit(t *testing.T) {
+	collector := newUniqueIDCollector(2)
+
+	shouldContinue := collector.add([]string{"sm1", "sm1", "sm2", "sm3"})
+
+	if shouldContinue {
+		t.Fatal("expected collector to stop at the unique ID limit")
+	}
+	if !slices.Equal(collector.ids, []string{"sm1", "sm2"}) {
+		t.Fatalf("expected two unique IDs, got %v", collector.ids)
+	}
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -96,7 +96,9 @@ main.go
   - Normal line output sorts IDs by numeric video ID.
   - `--dedupe` removes duplicate IDs **before** sorting/output. In unordered `--no-sort` line output, the first occurrence that reaches the writer is kept.
   - `--no-sort && !--json` uses an unordered streaming path: input target order, page order, and API item order are not guaranteed. Fetched batches are written by a single stdout writer as they arrive.
-  - `--no-sort --max-videos N` emits the first N IDs that reach the writer and cancels remaining fetches best-effort.
+  - For normal line output and JSON output, `--max-videos N` is a per-target fetch cap: each input target may collect up to N filtered IDs before output formatting, dedupe, sorting, or JSON flattening.
+  - For unordered line output (`--no-sort && !--json`), `--max-videos N` is a global emitted-output cap: the first N IDs that reach the writer are emitted and remaining fetches are canceled best-effort.
+  - With `--no-sort --dedupe --max-videos N`, the global cap counts emitted unique IDs. The fetch side may read more than N raw IDs to find N unique IDs.
   - Run summary is emitted to stderr after processing (even on non-zero exit codes).
     - Format: `summary inputs=<n> valid=<n> invalid=<n> fetch_ok=<n> fetch_err=<n> output_count=<n>`.
     - `output_count` uses the actual emitted count.
@@ -142,9 +144,9 @@ main.go
   - `Accept: */*`
 - Pagination: fetch until API page end.
 - When `totalCount` is present, page 1 determines the bounded page range and later pages may be fetched concurrently up to `--page-concurrency`.
-- If `totalCount` is unavailable or `--max-videos` is set, fetching uses the sequential empty/404 termination path for compatibility.
+- If `totalCount` is unavailable or `--max-videos` is set, fetching uses the sequential empty/404 termination path for compatibility, so page-level concurrency does not apply.
 - `max-pages` stops after the given number of pages (best-effort, no error).
-- `max-videos` stops after collecting the given number of filtered IDs (best-effort, no error).
+- In normal line output and JSON output, `max-videos` stops each target after collecting the given number of filtered IDs (best-effort, no error). The unordered line-output writer owns the global emitted cap described above.
 - Filters:
   - `comment > commentCount`
   - `registeredAt` >= `dateafter`

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -77,10 +77,13 @@ Notes:
 - 結果は stdout、進捗とログは stderr に出力されます。`--logfile` でログ出力先を変更できます。
 - `concurrency`、`page-concurrency`、`retries` を 1 未満にするか、`timeout` を 0 以下にすると実行時エラーになります。
 - `--max-pages` と `--max-videos` は安全制限で、`0` で無効化されます。
+- 通常の行出力と JSON 出力では、`--max-videos N` は入力ターゲットごとの取得上限です。各ターゲットで最大 N 件のフィルタ済み ID を集めてから、出力整形、重複除外、ソート、JSON flattening を行います。
+- unordered 行出力（`--json` なしの `--no-sort`）では、`--max-videos N` は出力全体の上限です。writer に先に到着した N 件を出力し、残りの取得を best-effort でキャンセルします。
+- `--no-sort --dedupe --max-videos N` では、出力される unique ID の件数に上限がかかります。N 件の unique ID を見つけるために、N 件を超える raw ID を読む場合があります。
 - 上限に達した場合は取得を早期終了し、エラー扱いにせず best-effort の結果を返します。
 - 200/404 以外の HTTP ステータスがリトライ後も続く場合は取得エラー扱いになります。
 - HTTP 200 でも `meta.status != 200` の場合は警告ログを出しつつ処理を続行します。
-- `--page-concurrency` は各入力ターゲット内のページ取得並列数を制御します。最大同時リクエスト数の目安は `--concurrency * --page-concurrency` です。
+- `--page-concurrency` は、API が `totalCount` を返し、かつ `--max-videos` が未指定の場合にのみ、各入力ターゲット内のページ取得並列数を制御します。その bounded-page path での最大同時リクエスト数の目安は `--concurrency * --page-concurrency` です。
 - すべてのリクエスト（リトライ含む）に対してレート制限が適用され、HTTP 429 の `Retry-After` は可能な限り尊重されます。高い並列数を使う場合は API 負荷を抑えるため `--rate-limit` または `--min-interval` を併用してください。
 - stderr が TTY でない場合は進捗表示を自動で無効化します。`--progress` で強制表示、`--no-progress` で無効化します（優先）。
 - 処理後に実行サマリを stderr に出力します（非0終了時も含む）。
@@ -89,7 +92,6 @@ Notes:
 - 通常の行出力は、`--no-sort` を指定しない限り動画IDの数値順にソートします。
 - `--dedupe` を指定すると動画IDの重複を除外してからソート/出力します。`--no-sort` 併用時は writer に先に到着した occurrence を採用します。
 - `--no-sort` は行出力向けの unordered fast mode です。入力ターゲット順、ページ順、API items 順は保証されず、取得完了した結果から出力されます。
-- `--no-sort --max-videos N` では writer に先に到着した N 件を出力し、残りの取得を best-effort でキャンセルします。
 - `--json` は stdout に単一の JSON オブジェクトを出力します。`--tab`/`--url` は JSON の `items` に影響せず、サマリは引き続き stderr に出力します。
 
 ## Design

--- a/internal/niconico/unique_collection.go
+++ b/internal/niconico/unique_collection.go
@@ -1,0 +1,102 @@
+package niconico
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// GetUniqueVideoList retrieves unique video IDs for a user.
+func GetUniqueVideoList(
+	ctx context.Context,
+	userID string,
+	commentCount int,
+	afterDate time.Time,
+	beforeDate time.Time,
+	baseURL string,
+	retries int,
+	httpClientTimeout time.Duration,
+	limiter *RateLimiter,
+	maxPages int,
+	maxVideos int,
+	logger *slog.Logger,
+) ([]string, error) {
+	return collectUniqueVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger,
+		func(page int) string {
+			return fmt.Sprintf("%s/users/%s/videos?pageSize=%d&page=%d", baseURL, userID, pageSize, page)
+		},
+		parseUserVideoPage,
+	)
+}
+
+// GetUniqueMylistVideoList retrieves unique video IDs for a mylist.
+func GetUniqueMylistVideoList(
+	ctx context.Context,
+	mylistID string,
+	commentCount int,
+	afterDate time.Time,
+	beforeDate time.Time,
+	baseURL string,
+	retries int,
+	httpClientTimeout time.Duration,
+	limiter *RateLimiter,
+	maxPages int,
+	maxVideos int,
+	logger *slog.Logger,
+) ([]string, error) {
+	return collectUniqueVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger,
+		func(page int) string {
+			return fmt.Sprintf("%s/mylists/%s?pageSize=%d&page=%d", baseURL, mylistID, pageSize, page)
+		},
+		parseMylistPage,
+	)
+}
+
+func collectUniqueVideoList(
+	ctx context.Context,
+	commentCount int,
+	afterDate time.Time,
+	beforeDate time.Time,
+	retries int,
+	httpClientTimeout time.Duration,
+	limiter *RateLimiter,
+	maxPages int,
+	maxVideos int,
+	logger *slog.Logger,
+	requestURL func(page int) string,
+	parsePage parsePageFunc,
+) ([]string, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	ids := make([]string, 0, maxVideos)
+	seen := make(map[string]struct{}, maxVideos)
+	for page := 1; ; page++ {
+		if maxPages > 0 && page > maxPages {
+			return ids, nil
+		}
+		parsed, err := fetchPage(ctx, requestURL(page), httpClientTimeout, retries, limiter, logger, parsePage)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, nil
+			}
+			return ids, err
+		}
+		if parsed.NotFound || len(parsed.Items) == 0 {
+			return ids, nil
+		}
+		for _, id := range filterItems(parsed.Items, commentCount, afterDate, beforeDate) {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+			if maxVideos > 0 && len(ids) >= maxVideos {
+				return ids, nil
+			}
+		}
+	}
+}

--- a/internal/niconico/video_list_visit.go
+++ b/internal/niconico/video_list_visit.go
@@ -8,8 +8,8 @@ import (
 	"time"
 )
 
-// GetUniqueVideoList retrieves unique video IDs for a user.
-func GetUniqueVideoList(
+// VisitVideoList visits filtered raw video IDs for each user page until the visitor stops.
+func VisitVideoList(
 	ctx context.Context,
 	userID string,
 	commentCount int,
@@ -20,10 +20,10 @@ func GetUniqueVideoList(
 	httpClientTimeout time.Duration,
 	limiter *RateLimiter,
 	maxPages int,
-	maxVideos int,
+	visitor func([]string) bool,
 	logger *slog.Logger,
-) ([]string, error) {
-	return collectUniqueVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger,
+) error {
+	return visitVideoListPages(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, visitor, logger,
 		func(page int) string {
 			return fmt.Sprintf("%s/users/%s/videos?pageSize=%d&page=%d", baseURL, userID, pageSize, page)
 		},
@@ -31,8 +31,8 @@ func GetUniqueVideoList(
 	)
 }
 
-// GetUniqueMylistVideoList retrieves unique video IDs for a mylist.
-func GetUniqueMylistVideoList(
+// VisitMylistVideoList visits filtered raw video IDs for each mylist page until the visitor stops.
+func VisitMylistVideoList(
 	ctx context.Context,
 	mylistID string,
 	commentCount int,
@@ -43,10 +43,10 @@ func GetUniqueMylistVideoList(
 	httpClientTimeout time.Duration,
 	limiter *RateLimiter,
 	maxPages int,
-	maxVideos int,
+	visitor func([]string) bool,
 	logger *slog.Logger,
-) ([]string, error) {
-	return collectUniqueVideoList(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, maxVideos, logger,
+) error {
+	return visitVideoListPages(ctx, commentCount, afterDate, beforeDate, retries, httpClientTimeout, limiter, maxPages, visitor, logger,
 		func(page int) string {
 			return fmt.Sprintf("%s/mylists/%s?pageSize=%d&page=%d", baseURL, mylistID, pageSize, page)
 		},
@@ -54,7 +54,8 @@ func GetUniqueMylistVideoList(
 	)
 }
 
-func collectUniqueVideoList(
+// visitVideoListPages visits filtered raw IDs in page order.
+func visitVideoListPages(
 	ctx context.Context,
 	commentCount int,
 	afterDate time.Time,
@@ -63,40 +64,29 @@ func collectUniqueVideoList(
 	httpClientTimeout time.Duration,
 	limiter *RateLimiter,
 	maxPages int,
-	maxVideos int,
+	visitor func([]string) bool,
 	logger *slog.Logger,
 	requestURL func(page int) string,
 	parsePage parsePageFunc,
-) ([]string, error) {
+) error {
 	if logger == nil {
 		logger = slog.Default()
 	}
-
-	ids := make([]string, 0, maxVideos)
-	seen := make(map[string]struct{}, maxVideos)
-	for page := 1; ; page++ {
-		if maxPages > 0 && page > maxPages {
-			return ids, nil
-		}
+	for page := 1; maxPages == 0 || page <= maxPages; page++ {
 		parsed, err := fetchPage(ctx, requestURL(page), httpClientTimeout, retries, limiter, logger, parsePage)
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return nil, nil
+				return nil
 			}
-			return ids, err
+			return err
 		}
 		if parsed.NotFound || len(parsed.Items) == 0 {
-			return ids, nil
+			return nil
 		}
-		for _, id := range filterItems(parsed.Items, commentCount, afterDate, beforeDate) {
-			if _, ok := seen[id]; ok {
-				continue
-			}
-			seen[id] = struct{}{}
-			ids = append(ids, id)
-			if maxVideos > 0 && len(ids) >= maxVideos {
-				return ids, nil
-			}
+		ids := filterItems(parsed.Items, commentCount, afterDate, beforeDate)
+		if len(ids) > 0 && !visitor(ids) {
+			return nil
 		}
 	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Clarify `--max-videos` / `--page-concurrency` semantics and fix fast unordered `--max-videos` behavior for cancellation and dedupe.

## What / Why

- Document that normal line output and JSON use `--max-videos` as a per-target fetch cap, while unordered line output uses it as a global emitted-output cap.
- Document that `--no-sort --dedupe --max-videos N` caps emitted unique IDs and may read more than N raw IDs to find them.
- Make shared input streaming cancellation-aware so fast unordered early caps can clean up closable blocked stdin/input-file readers.
- Preserve input error precedence and write-error precedence around cancellation paths.
- Keep normal/JSON per-target fetch-cap behavior intact while disabling the per-target raw fetch cap only for fast unordered dedupe+max-videos.

## Related issues

Closes #285
Closes #286
Closes #287

## Testing

Evidence paths:
- `.omo/evidence/task-T2-issue-285-287-fast-unordered.txt` - RED #287 duplicate-heavy under-emission test.
- `.omo/evidence/task-T3-issue-285-287-fast-unordered.txt` - RED #286 blocked stdin/input-file cleanup tests.
- `.omo/evidence/task-T7-issue-285-287-fast-unordered.txt` - GREEN #287 fast unordered dedupe cap override.
- `.omo/evidence/task-T8-issue-285-287-fast-unordered.txt` - GREEN #286 blocked reader cleanup plus race probe.
- `.omo/evidence/task-T9-issue-285-287-fast-unordered.txt` - GREEN input/write error precedence lock-down.
- `.omo/evidence/task-T10-issue-285-287-fast-unordered.txt` - docs reconciliation after fixes.
- `.omo/evidence/task-T11-issue-285-287-fast-unordered.txt` - targeted fast unordered regression suite.
- `.omo/evidence/task-T12-issue-285-287-fast-unordered.txt` - shared input/output regression suite.
- `.omo/evidence/task-T13-issue-285-287-fast-unordered.txt` - docs/help verification.
- `.omo/evidence/task-T14-issue-285-287-fast-unordered.txt` - final CI-parity verification and generated drift check.

Commands run so far:

```bash
go test ./cmd -run TestRunRootCmdNoSortDedupeMaxVideosEmitsEnoughUniqueIDs -count=1
go test ./cmd -run "TestRunRootCmdNoSort.*(BlockedStdin|BlockedInputFile|InputStream).*" -count=1
go test ./cmd -run "TestRunRootCmdNoSort(DedupeMaxVideosEmitsEnoughUniqueIDs|MaxVideosStopsSingleTargetPagination)" -count=1
go test ./cmd -run TestRunRootCmdMaxVideosStopsSingleTargetPagination -count=1
go test -race ./cmd -run "TestRunRootCmdNoSort.*" -count=1
go test ./cmd -run "TestRunRootCmdNoSort(MaxVideosReturnsInputFileReadErrorAfterCap|ContextCancelDoesNotWaitForBlockedInputErrors)|Test.*Input" -count=1
go test ./cmd -run "TestRunRootCmdNoSort" -count=1
go test ./cmd -run "Test.*(Input|JSON|Output|MaxVideos|PageConcurrency).*" -count=1
rg -n "max-videos|page-concurrency|per target|global|unique|totalCount|best-effort" README.md docs/README.ja.md docs/DESIGN.md
go run . --help
git ls-files "*.go" | xargs gofmt -w && git diff --exit-code -- "*.go"
go vet ./...
golangci-lint run ./...
go test ./...
go test -race ./...
go mod tidy && go generate ./... && git diff --exit-code
```

Results available so far:
- Expected RED before fixes:
  - #287 test failed with `expected sm1 and sm2 stdout output, got "sm1\n"`.
  - #286 cleanup tests failed with `expected canceled input producer to close blocked reader`.
- Focused GREEN evidence after fixes:
  - `go test ./cmd -run "TestRunRootCmdNoSort(DedupeMaxVideosEmitsEnoughUniqueIDs|MaxVideosStopsSingleTargetPagination)" -count=1`: PASS.
  - `go test ./cmd -run TestRunRootCmdMaxVideosStopsSingleTargetPagination -count=1`: PASS.
  - `go test ./cmd -run "TestRunRootCmdNoSort.*(BlockedStdin|BlockedInputFile|InputStream).*" -count=1`: PASS.
  - `go test -race ./cmd -run "TestRunRootCmdNoSort.*" -count=1`: PASS.
  - `go test ./cmd -run "TestRunRootCmdNoSort(MaxVideosReturnsInputFileReadErrorAfterCap|ContextCancelDoesNotWaitForBlockedInputErrors)|Test.*Input" -count=1`: PASS.
  - `go test ./cmd -run "TestRunRootCmdNoSort" -count=1`: PASS.
  - `go test ./cmd -run "Test.*(Input|JSON|Output|MaxVideos|PageConcurrency).*" -count=1`: PASS.
- docs/help verification commands: PASS.
- T14 final verification:
  - `git ls-files "*.go" | xargs gofmt -w && git diff --exit-code -- "*.go"`: exit 1 only because existing tracked Go source/test diffs were already present; gofmt completed and no unrelated edits were reverted.
  - `go vet ./...`: PASS.
  - `golangci-lint run ./...`: PASS, 0 issues.
  - `go test ./...`: PASS.
  - `go test -race ./...`: PASS.
  - `go mod tidy && go generate ./... && git diff --exit-code`: exit 1 only because intended existing source/docs/product diffs were present; no unexpected `go.mod`, `go.sum`, or generated-file drift was observed.

## Fix log

- 2026-06-17 T7: Fixed #287 by letting fast unordered dedupe+max-videos fetch without the per-target raw cap so the writer can emit enough unique IDs; verified focused fast unordered and normal max-videos pagination tests.
- 2026-06-17 T8: Fixed #286 by making closable stdin/input-file readers unblock on cancellation while keeping close handling idempotent; verified focused blocked cleanup tests and no-sort race tests.
- 2026-06-17 T9: Added input/write error precedence coverage around cancellation; verified existing max-videos input-file read error, context-cancel blocked input behavior, normal/JSON input error surfaces, and race probe.
- 2026-06-17 T10: Reconciled docs after implementation; verified docs describe per-target caps, global unordered caps, unique-ID nuance, and `page-concurrency` `totalCount` / no-`max-videos` condition.

- 2026-06-18: Moved unique-ID collection from internal/niconico to cmd; niconico now visits filtered raw page batches and cmd owns dedupe/cap orchestration.
- 2026-06-18: Removed max-videos-sized preallocation and added a 1,000,000,000-limit regression test plus real CLI smoke coverage.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed
- [x] Checked release-generated third-party notices if dependencies changed
  - No dependency changes; `go.mod`, `go.sum`, and `THIRD_PARTY_NOTICES.md` have no diff.

