### PR TITLE
chore: add Go toolchain directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/sh4869221b/go-nico-list
 
 go 1.26.1
 
+toolchain go1.26.6
+
 require (
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/term v0.45.0


### PR DESCRIPTION
## Summary

Add an explicit Go toolchain directive to `go.mod` while preserving the existing minimum Go version.

## What / Why

- Keep `go 1.26.1` unchanged as the module's minimum Go version.
- Add `toolchain go1.26.6` so development, CI, and release workflows using `go-version-file: go.mod` select the current Go 1.26 patch toolchain.
- This also prepares the repository for a later Go 1.27 toolchain-only upgrade without unnecessarily raising the module's minimum Go version.

## Related issues

None.

## Testing

Not run locally; this is a `go.mod` metadata-only change. Repository CI will run the normal `go mod tidy`, generation drift, gofmt, vet, golangci-lint, test, and race-test checks.

```bash
# not run locally
```

## Fix log

- 2026-08-21: added `toolchain go1.26.6` to `go.mod`.

## Breaking change

- [ ] Yes
- [x] No

## Checklist

- [ ] `gofmt -w .`
- [ ] `go vet ./...`
- [ ] `golangci-lint run ./...`
- [ ] `go test ./...`
- [x] Updated docs (`README.md` / `DESIGN.md`) if behavior changed (not applicable; no behavior change)
- [x] Checked release-generated third-party notices if dependencies changed (not applicable; no dependency change)
